### PR TITLE
fix: appVersion formatting in Chart.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: cfgate
 description: Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access
 type: application
 version: 1.0.19
-appVersion: "v0.1.0-alpha.19"
+appVersion: "0.1.0-alpha.19"
 kubeVersion: ">= 1.26.0-0"
 
 keywords:


### PR DESCRIPTION
OCI images uses [`0.1.0-alpha.19`](https://github.com/cfgate/cfgate/pkgs/container/cfgate/736868256?tag=0.1.0-alpha.19) without the `v`