### PR TITLE
fix(chart): sync 1.0.20 release housekeeping

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ on:
       - "values.schema.json"
       - "templates/**"
       - "ci/**"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
+      - ".github/actionlint.yaml"
+      - "cliff.toml"
+      - "artifacthub-repo.yml"
   pull_request:
     branches: [main]
     paths:
@@ -18,7 +21,10 @@ on:
       - "values.schema.json"
       - "templates/**"
       - "ci/**"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
+      - ".github/actionlint.yaml"
+      - "cliff.toml"
+      - "artifacthub-repo.yml"
   workflow_dispatch:
 
 permissions:
@@ -29,15 +35,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  actionlint:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: rhysd/actionlint@v1.7.12
+
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
-      - uses: azure/setup-helm@v4.3.1
+      - uses: azure/setup-helm@v5.0.0
         with:
-          version: v4.1.0
+          version: v4.1.4
 
       - name: Lint chart
         run: helm lint .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,25 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
 
       - id: version
-        run: echo "clean=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: echo "clean=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: azure/setup-helm@v4.3.1
+      - uses: azure/setup-helm@v5.0.0
         with:
-          version: v4.1.0
+          version: v4.1.4
+
+      - name: Validate chart version matches tag
+        run: |
+          CHART_VERSION="$(awk '/^version:/ {print $2; exit}' Chart.yaml)"
+          TAG_VERSION="${{ steps.version.outputs.clean }}"
+          if [ "$CHART_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Chart.yaml version ($CHART_VERSION) must match release tag ($TAG_VERSION)"
+            exit 1
+          fi
 
       - name: Lint chart
         run: helm lint .
@@ -41,28 +52,38 @@ jobs:
           OUTPUT=$(helm push dist/cfgate-*.tgz oci://ghcr.io/cfgate/charts 2>&1)
           echo "$OUTPUT"
           DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]+')
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: sigstore/cosign-installer@v4
+      - uses: sigstore/cosign-installer@v4.1.1
 
       - name: Sign chart
         run: cosign sign --yes ${{ env.CHART_REF }}@${{ steps.push.outputs.digest }}
 
-      - uses: oras-project/setup-oras@v1
+      - uses: oras-project/setup-oras@v2.0.0
 
       - name: Tag latest
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
           oras tag ${{ env.CHART_REF }}:${{ steps.version.outputs.clean }} latest
 
-      - uses: softprops/action-gh-release@v2
+      - name: Generate release notes
+        id: changelog
+        uses: orhun/git-cliff-action@v4
         with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
+      - uses: softprops/action-gh-release@v2.6.1
+        with:
+          body: ${{ steps.changelog.outputs.content }}
           files: dist/cfgate-*.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,76 @@
 All notable changes to the cfgate Helm chart are documented in this file.
 
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Correct Artifact Hub shield URL
+
+### CI/CD
+
+- Add Renovate for dependency automation
+- Bump cosign-installer to v4 for Node 24 compatibility
+
+### Maintenance
+
+- **(deps)** Update docker/login-action action to v4
+
+## [1.0.19] - 2026-03-15
+
+### Maintenance
+
+- Add namespace RBAC and bump to v0.1.0-alpha.19
+- Bump default cloudflared image to 2026.3.0-h2c.1
+
+## [1.0.18] - 2026-02-24
+
+### Features
+
+- Bump to 0.1.0-alpha.18, resync tunnel CRD
+
+## [1.0.17] - 2026-02-24
+
+### Bug Fixes
+
+- Remove v prefix from default cloudflared image tag, bump to alpha.17
+
+## [1.0.16] - 2026-02-24
+
+### Features
+
+- Bump to 0.1.0-alpha.16, default image to inherent-design fork
+
+## [1.0.15] - 2026-02-24
+
+### Features
+
+- Bump to 0.1.0-alpha.15, resync tunnel CRD
+
+## [1.0.13] - 2026-02-21
+
+### Features
+
+- Bump to 0.1.0-alpha.13, resync CRDs, fix README prose
+
+## [1.0.12] - 2026-02-19
+
+### Maintenance
+
+- Add shields, clean up README
+- Fix chart maintainer name
+
+## [1.0.11] - 2026-02-19
+
+### Bug Fixes
+
+- **(ci)** Add docker login for cosign registry auth
+
+### Maintenance
+
+- Add cliff config and generate changelog
+- Bump chart version to 1.0.11
+
 ## [1.0.10] - 2026-02-19
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,10 +103,19 @@ helm template cfgate . --set rbac.create=false
 Update `Chart.yaml`:
 - `version`: Chart version (independent of app)
 - `appVersion`: cfgate release version
+- release tags must match `Chart.yaml version` without the leading `v`
+
+### Changelog
+
+`CHANGELOG.md` is generated from git history via `git-cliff`.
+
+- regenerate it locally when preparing chart releases or housekeeping updates
+- do not hand-edit release entries
 
 ### CI Integration
 
 Chart changes should pass:
+- `actionlint`
 - `helm lint`
 - `helm template` with default values
 - `helm template` with `ci/default-values.yaml`

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cfgate
 description: Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access
 type: application
-version: 1.0.19
-appVersion: "v0.1.0-alpha.19"
+version: 1.0.20
+appVersion: "0.1.0-alpha.20"
 kubeVersion: ">= 1.26.0-0"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Installs the cfgate controller, a Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access management.
 
+This chart currently targets cfgate `0.1.0-alpha.20`.
+
 The chart deploys:
 - Controller Deployment (with health probes, security context, resource limits)
 - CRDs (CloudflareTunnel, CloudflareDNS, CloudflareAccessPolicy)
@@ -16,7 +18,7 @@ The chart deploys:
 ## Prerequisites
 
 - Kubernetes 1.26+
-- Helm 3.x
+- Helm 3.x or 4.x
 - Gateway API CRDs installed:
 
 ```bash
@@ -186,22 +188,27 @@ Chart.yaml includes Artifact Hub annotations that control how the chart appears 
 
 When moving between release stages, update `Chart.yaml` annotations:
 
-**Alpha/Beta builds** (`appVersion: "0.1.0-alpha.13"`):
+**Alpha/Beta builds** (`appVersion: "0.0.0-alpha.1"`):
 ```yaml
 artifacthub.io/prerelease: "true"
 ```
 
-**Release candidates** (`appVersion: "0.1.0-rc.1"`):
+**Release candidates** (`appVersion: "0.0.0-rc.1"`):
 ```yaml
 artifacthub.io/prerelease: "true"
 ```
 
-**Stable releases** (`appVersion: "0.1.0"`):
+**Stable releases** (`appVersion: "0.0.0"`):
 ```yaml
 artifacthub.io/prerelease: "false"
 ```
 
-The `appVersion` in Chart.yaml is auto-synced during release (see `.github/workflows/release.yml`). The `artifacthub.io/prerelease` annotation must be updated manually before tagging a stable release.
+Update `Chart.yaml` manually before tagging:
+- set `version` to match the release tag without the leading `v`
+- set `appVersion` to the cfgate version the chart targets
+- set `artifacthub.io/prerelease` appropriately for prerelease vs stable publication
+
+The release workflow validates that the tag matches `Chart.yaml version`, but it does not rewrite chart metadata for you.
 
 ## Chart Development
 

--- a/ci/default-values.yaml
+++ b/ci/default-values.yaml
@@ -1,5 +1,5 @@
-# Minimal values for chart-testing
-# These values are used by ct lint to validate the chart
+# Minimal values for CI chart validation
+# These values are used by helm lint and helm template in CI
 
 replicaCount: 2
 

--- a/templates/crds/cloudflaretunnel.yaml
+++ b/templates/crds/cloudflaretunnel.yaml
@@ -138,7 +138,7 @@ spec:
                     maxItems: 20
                     type: array
                   image:
-                    default: ghcr.io/inherent-design/cloudflared:2026.3.0-h2c.1
+                    default: ghcr.io/inherent-design/cloudflared:2026.3.0-h2c.2
                     description: Image is the cloudflared container image.
                     maxLength: 255
                     type: string


### PR DESCRIPTION
## Summary
- sync the chart to cfgate v0.1.0-alpha.20, including the cloudflared CRD default and related docs/CI housekeeping
- normalize `Chart.yaml` `appVersion` to `0.1.0-alpha.20` so the default rendered controller image matches the published GHCR tag format
- keep git-cliff release notes in the tag workflow, but drop the release-time `CHANGELOG.md` writeback to `main`
- expand chart CI coverage to include workflow-related changes and `actionlint`
- closes #4 

## Test plan
- helm lint .
- helm template cfgate .
- helm template cfgate . -f ci/default-values.yaml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml")'
- docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.12
- git diff --check