### PR TITLE
chart: prepare cfgate 0.2.0-alpha.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the cfgate Helm chart are documented in this file.
 
 
+## [1.2.1] - 2026-04-12
+
+### Other
+
+- Sync cfgate alpha.21 surface
+- Target cfgate 0.2.0-alpha.1
+
 ## [Unreleased]
 
 ### Bug Fixes

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cfgate
 description: Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access
 type: application
-version: 1.0.21
-appVersion: "0.1.0-alpha.21"
+version: 1.2.1
+appVersion: "0.2.0-alpha.1"
 kubeVersion: ">= 1.26.0-0"
 
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cfgate
 description: Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access
 type: application
-version: 1.0.20
-appVersion: "0.1.0-alpha.20"
+version: 1.0.21
+appVersion: "0.1.0-alpha.21"
 kubeVersion: ">= 1.26.0-0"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 Installs the cfgate controller, a Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access management.
 
-This chart currently targets cfgate `0.1.0-alpha.20`.
+This chart currently targets cfgate `0.1.0-alpha.21`.
+
+The current cfgate surface managed by this chart keeps `CloudflareAccessPolicy` scoped to `Gateway` and `HTTPRoute`. Access mTLS support and retired route kinds are not part of the shipped product surface.
 
 The chart deploys:
 - Controller Deployment (with health probes, security context, resource limits)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Installs the cfgate controller, a Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access management.
 
-This chart currently targets cfgate `0.1.0-alpha.21`.
+This chart currently targets cfgate `0.2.0-alpha.1`.
 
 The current cfgate surface managed by this chart keeps `CloudflareAccessPolicy` scoped to `Gateway` and `HTTPRoute`. Access mTLS support and retired route kinds are not part of the shipped product surface.
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -33,6 +33,7 @@ Quick start:
    - Account > Cloudflare Tunnel > Edit
    - Zone > DNS > Edit
    - Account > Access: Apps and Policies > Edit
+   - Account > Access: Service Tokens > Edit (if using service-token-backed Access policies)
    - Account > Account Settings > Read (if using accountName instead of accountId)
 
 2. Create a secret with your credentials:

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -6,133 +6,110 @@ metadata:
   labels:
     {{- include "cfgate.labels" . | nindent 4 }}
 rules:
-  # Core resources - secrets
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  # Core resources - services (read-only)
-  - apiGroups:
-      - ""
-    resources:
-      - services
-    verbs:
-      - get
-      - list
-      - watch
-  # Core resources - namespaces (read-only)
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
-  # Core resources - events
-  - apiGroups:
-      - ""
-      - events.k8s.io
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-  # Apps resources - deployments (for cloudflared)
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  # cfgate.io CRDs
-  - apiGroups:
-      - cfgate.io
-    resources:
-      - cloudflareaccesspolicies
-      - cloudflarednses
-      - cloudflaretunnels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  # cfgate.io CRDs - finalizers
-  - apiGroups:
-      - cfgate.io
-    resources:
-      - cloudflareaccesspolicies/finalizers
-      - cloudflarednses/finalizers
-      - cloudflaretunnels/finalizers
-    verbs:
-      - update
-  # cfgate.io CRDs - status
-  - apiGroups:
-      - cfgate.io
-    resources:
-      - cloudflareaccesspolicies/status
-      - cloudflarednses/status
-      - cloudflaretunnels/status
-    verbs:
-      - get
-      - patch
-      - update
-  # Leader election
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  # Gateway API resources (read-only)
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - gatewayclasses
-      - gateways
-      - grpcroutes
-      - httproutes
-      - referencegrants
-      - tcproutes
-      - udproutes
-    verbs:
-      - get
-      - list
-      - watch
-  # Gateway API resources - status
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - gatewayclasses/status
-      - gateways/status
-      - httproutes/status
-      - tcproutes/status
-      - udproutes/status
-    verbs:
-      - get
-      - patch
-      - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cfgate.io
+  resources:
+  - cloudflareaccesspolicies
+  - cloudflarednses
+  - cloudflaretunnels
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cfgate.io
+  resources:
+  - cloudflareaccesspolicies/finalizers
+  - cloudflarednses/finalizers
+  - cloudflaretunnels/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cfgate.io
+  resources:
+  - cloudflareaccesspolicies/status
+  - cloudflarednses/status
+  - cloudflaretunnels/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  - httproutes
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - httproutes/status
+  verbs:
+  - get
+  - patch
+  - update
 {{- end }}

--- a/templates/crds/cloudflareaccesspolicy.yaml
+++ b/templates/crds/cloudflareaccesspolicy.yaml
@@ -41,15 +41,14 @@ spec:
           CloudflareAccessPolicy is the Schema for the cloudflareaccesspolicies API.
 
           CloudflareAccessPolicy manages Cloudflare Access Applications and Policies for zero-trust
-          access control. It attaches to Gateway API resources (Gateway, HTTPRoute, GRPCRoute,
-          TCPRoute, UDPRoute) using the targetRefs pattern and creates corresponding Access
-          Applications in Cloudflare.
+          access control. It attaches to Gateway API Gateway and HTTPRoute resources using the
+          targetRefs pattern and creates corresponding Access Applications in Cloudflare.
 
           Access rules are organized into implementation tiers based on IdP requirements:
             - P0: IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken (no IdP)
             - P1: Email, EmailList, EmailDomain, OIDCClaim (basic IdP required)
             - P2: GSuiteGroup (Google Workspace required)
-            - P3: deferred to v0.2.0 (Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.)
+            - P3: not in current product scope (Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.)
 
           Status conditions:
             - Ready: policy is fully applied to all targets
@@ -59,7 +58,6 @@ spec:
             - ApplicationCreated: Access Application exists in Cloudflare
             - PoliciesAttached: Access policies are attached to the application
             - ServiceTokensReady: all service tokens have been created
-            - MTLSConfigured: mTLS rule is configured (if enabled)
         properties:
           apiVersion:
             description: |-
@@ -334,45 +332,6 @@ spec:
                     rule: has(self.name) || has(self.cloudflareId)
                 maxItems: 50
                 type: array
-              mtls:
-                description: MTLS configures certificate-based authentication.
-                properties:
-                  associatedHostnames:
-                    description: AssociatedHostnames limits mTLS to specific hostnames.
-                    items:
-                      type: string
-                    maxItems: 25
-                    type: array
-                  enabled:
-                    default: false
-                    description: Enabled activates mTLS requirement.
-                    type: boolean
-                  rootCaSecretRef:
-                    description: RootCASecretRef references the CA certificate(s)
-                      for validation.
-                    properties:
-                      key:
-                        default: ca.crt
-                        description: Key within Secret (defaults to ca.crt).
-                        maxLength: 253
-                        type: string
-                      name:
-                        description: Name of the Secret.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  ruleName:
-                    description: |-
-                      RuleName is the name of the mTLS rule in Cloudflare.
-                      Defaults to CR name if omitted.
-                    maxLength: 255
-                    type: string
-                required:
-                - enabled
-                type: object
               policies:
                 description: Policies define access rules (evaluated in order).
                 items:
@@ -442,7 +401,7 @@ spec:
                             - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
                             - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
                             - P2 (Google Workspace): GSuiteGroup
-                            - P3 (deferred to v0.2.0): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
+                            - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
 
                           SDK types map directly to cloudflare-go v6.6.0: IPRule, IPListRule, CountryRule,
                           EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
@@ -633,7 +592,7 @@ spec:
                             - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
                             - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
                             - P2 (Google Workspace): GSuiteGroup
-                            - P3 (deferred to v0.2.0): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
+                            - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
 
                           SDK types map directly to cloudflare-go v6.6.0: IPRule, IPListRule, CountryRule,
                           EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
@@ -845,7 +804,7 @@ spec:
                             - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
                             - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
                             - P2 (Google Workspace): GSuiteGroup
-                            - P3 (deferred to v0.2.0): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
+                            - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
 
                           SDK types map directly to cloudflare-go v6.6.0: IPRule, IPListRule, CountryRule,
                           EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
@@ -1092,9 +1051,6 @@ spec:
                     enum:
                     - Gateway
                     - HTTPRoute
-                    - GRPCRoute
-                    - TCPRoute
-                    - UDPRoute
                     type: string
                   name:
                     description: Name is the name of the target resource.
@@ -1118,10 +1074,8 @@ spec:
                 x-kubernetes-validations:
                 - message: group must be gateway.networking.k8s.io
                   rule: self.group == 'gateway.networking.k8s.io'
-                - message: kind must be Gateway, HTTPRoute, GRPCRoute, TCPRoute, or
-                    UDPRoute
-                  rule: self.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'TCPRoute',
-                    'UDPRoute']
+                - message: kind must be Gateway or HTTPRoute
+                  rule: self.kind in ['Gateway', 'HTTPRoute']
               targetRefs:
                 description: TargetRefs identifies multiple targets for policy attachment.
                 items:
@@ -1129,9 +1083,9 @@ spec:
                     PolicyTargetReference identifies a Gateway API resource for Access policy attachment.
 
                     PolicyTargetReference follows the Gateway API LocalPolicyTargetReferenceWithSectionName
-                    pattern for policy attachment. It targets Gateway API resources (Gateway, HTTPRoute,
-                    GRPCRoute, TCPRoute, UDPRoute) and extracts hostnames from those resources to create
-                    corresponding Cloudflare Access applications.
+                    pattern for policy attachment. It targets Gateway API Gateway and HTTPRoute resources
+                    and extracts hostnames from those resources to create corresponding Cloudflare Access
+                    applications.
 
                     Cross-namespace references require a ReferenceGrant in the target namespace that permits
                     CloudflareAccessPolicy resources from the policy's namespace.
@@ -1145,9 +1099,6 @@ spec:
                       enum:
                       - Gateway
                       - HTTPRoute
-                      - GRPCRoute
-                      - TCPRoute
-                      - UDPRoute
                       type: string
                     name:
                       description: Name is the name of the target resource.
@@ -1171,10 +1122,8 @@ spec:
                   x-kubernetes-validations:
                   - message: group must be gateway.networking.k8s.io
                     rule: self.group == 'gateway.networking.k8s.io'
-                  - message: kind must be Gateway, HTTPRoute, GRPCRoute, TCPRoute,
-                      or UDPRoute
-                    rule: self.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'TCPRoute',
-                      'UDPRoute']
+                  - message: kind must be Gateway or HTTPRoute
+                    rule: self.kind in ['Gateway', 'HTTPRoute']
                 maxItems: 16
                 type: array
             required:
@@ -1215,9 +1164,6 @@ spec:
                           enum:
                           - Gateway
                           - HTTPRoute
-                          - GRPCRoute
-                          - TCPRoute
-                          - UDPRoute
                           type: string
                         name:
                           description: Name is the name of the target resource.
@@ -1241,10 +1187,8 @@ spec:
                       x-kubernetes-validations:
                       - message: group must be gateway.networking.k8s.io
                         rule: self.group == 'gateway.networking.k8s.io'
-                      - message: kind must be Gateway, HTTPRoute, GRPCRoute, TCPRoute,
-                          or UDPRoute
-                        rule: self.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'TCPRoute',
-                          'UDPRoute']
+                      - message: kind must be Gateway or HTTPRoute
+                        rule: self.kind in ['Gateway', 'HTTPRoute']
                     conditions:
                       description: Conditions for this specific target.
                       items:
@@ -1383,9 +1327,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              mtlsRuleId:
-                description: MTLSRuleID is the Cloudflare mTLS rule ID.
-                type: string
               observedGeneration:
                 description: ObservedGeneration is the last generation processed.
                 format: int64


### PR DESCRIPTION
## Summary
- bump chart metadata to `1.2.1` / `0.2.0-alpha.1`
- keep the synced Gateway/HTTPRoute-only AccessPolicy surface
- refresh chart release docs and changelog output

## Notes
- prerelease only
- chart is ready to merge once cfgate `0.2.0-alpha.1` publication is complete
- Access mTLS support is not part of the shipped cfgate surface
- CloudflareAccessPolicy targets are Gateway and HTTPRoute only
- retired route kinds are not part of the current product surface

## Test plan
- `helm lint .`
- `helm template cfgate .`
- `helm template cfgate . -f ci/default-values.yaml`
- `helm template cfgate . --set installCRDs=false`
- `helm template cfgate . --set rbac.create=false`
