### PR TITLE
chart: target cfgate 0.2.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the cfgate Helm chart are documented in this file.
 
 
+## [1.2.2] - 2026-04-28
+
+### Documentation
+
+- Refresh changelog for 1.2.1
+
+### Maintenance
+
+- **(deps)** Update softprops/action-gh-release action to v3
+
+### Other
+
+- Sync cfgate alpha.21 surface
+- Target cfgate 0.2.0-alpha.1
+- Merge remote-tracking branch 'origin/main' into dev
+- Target cfgate 0.2.0-alpha.2
+
 ## [1.2.1] - 2026-04-12
 
 ### Other

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cfgate
 description: Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access
 type: application
-version: 1.2.1
-appVersion: "0.2.0-alpha.1"
+version: 1.2.2
+appVersion: "0.2.0-alpha.2"
 kubeVersion: ">= 1.26.0-0"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Installs the cfgate controller, a Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access management.
 
-This chart currently targets cfgate `0.2.0-alpha.1`.
+This chart currently targets cfgate `0.2.0-alpha.2`.
 
 The current cfgate surface managed by this chart keeps `CloudflareAccessPolicy` scoped to `Gateway` and `HTTPRoute`. Access mTLS support and retired route kinds are not part of the shipped product surface.
 


### PR DESCRIPTION
## Summary
- bump chart metadata to `1.2.2` / `0.2.0-alpha.2`
- refresh chart README and generated changelog

## Test plan
- `helm lint .`
- `helm template cfgate .`
- `helm template cfgate . -f ci/default-values.yaml`
- `helm template cfgate . --set installCRDs=false`
- `helm template cfgate . --set rbac.create=false`

Note: stale `0.2.0-alpha.1` / `1.2.1` matches are historical changelog entries only.