### PR TITLE
Release cfgate chart 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 All notable changes to the cfgate Helm chart are documented in this file.
 
 
-## [1.2.2] - 2026-04-28
+## [1.3.0] - 2026-05-15
 
-### Documentation
+### Features
 
-- Refresh changelog for 1.2.1
+- Sync cfgate 0.2.0-alpha.3 chart assets
+
+## [1.2.2] - 2026-04-29
 
 ### Maintenance
 
@@ -15,23 +17,25 @@ All notable changes to the cfgate Helm chart are documented in this file.
 
 ### Other
 
-- Sync cfgate alpha.21 surface
-- Target cfgate 0.2.0-alpha.1
-- Merge remote-tracking branch 'origin/main' into dev
 - Target cfgate 0.2.0-alpha.2
 
 ## [1.2.1] - 2026-04-12
+
+### Documentation
+
+- Refresh changelog for 1.2.1
 
 ### Other
 
 - Sync cfgate alpha.21 surface
 - Target cfgate 0.2.0-alpha.1
 
-## [Unreleased]
+## [1.0.20] - 2026-04-11
 
 ### Bug Fixes
 
 - Correct Artifact Hub shield URL
+- **(chart)** Sync 1.0.20 release housekeeping
 
 ### CI/CD
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cfgate
 description: Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access
 type: application
-version: 1.2.2
-appVersion: "0.2.0-alpha.2"
+version: 1.3.0
+appVersion: "0.2.0-alpha.3"
 kubeVersion: ">= 1.26.0-0"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 Installs the cfgate controller, a Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access management.
 
-This chart currently targets cfgate `0.2.0-alpha.2`.
+This chart currently targets cfgate `0.2.0-alpha.3`.
 
-The current cfgate surface managed by this chart keeps `CloudflareAccessPolicy` scoped to `Gateway` and `HTTPRoute`. Access mTLS support and retired route kinds are not part of the shipped product surface.
+The current cfgate surface managed by this chart includes separate `CloudflareAccessApplication` and `CloudflareAccessPolicy` CRDs for Access application and policy lifecycle management.
 
 The chart deploys:
 - Controller Deployment (with health probes, security context, resource limits)
-- CRDs (CloudflareTunnel, CloudflareDNS, CloudflareAccessPolicy)
+- CRDs (CloudflareTunnel, CloudflareDNS, CloudflareAccessApplication, CloudflareAccessPolicy)
 - ClusterRole and ClusterRoleBinding
 - ServiceAccount
 - Metrics Service (optional ServiceMonitor for Prometheus)
@@ -24,7 +24,7 @@ The chart deploys:
 - Gateway API CRDs installed:
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
 Gateway API CRDs are a cluster-level prerequisite, not a chart dependency. They may already be installed if you run Istio, Cilium, Envoy Gateway, or another Gateway API implementation.
@@ -49,11 +49,12 @@ helm upgrade cfgate oci://ghcr.io/cfgate/charts/cfgate \
 helm uninstall cfgate --namespace cfgate-system
 ```
 
-CRDs are not deleted on uninstall (annotated with `helm.sh/resource-policy: keep`). This prevents accidental deletion of all CloudflareTunnel, CloudflareDNS, and CloudflareAccessPolicy resources in the cluster. To remove CRDs manually:
+CRDs are not deleted on uninstall (annotated with `helm.sh/resource-policy: keep`). This prevents accidental deletion of all CloudflareTunnel, CloudflareDNS, CloudflareAccessApplication, and CloudflareAccessPolicy resources in the cluster. To remove CRDs manually:
 
 ```bash
 kubectl delete crd cloudflaretunnels.cfgate.io
 kubectl delete crd cloudflarednses.cfgate.io
+kubectl delete crd cloudflareaccessapplications.cfgate.io
 kubectl delete crd cloudflareaccesspolicies.cfgate.io
 ```
 
@@ -164,7 +165,7 @@ metrics:
 ## Next Steps
 
 After installing the chart, see the [cfgate documentation](https://github.com/cfgate/cfgate) for:
-- Creating CloudflareTunnel, CloudflareDNS, and CloudflareAccessPolicy resources
+- Creating CloudflareTunnel, CloudflareDNS, CloudflareAccessApplication, and CloudflareAccessPolicy resources
 - Setting up Gateway API GatewayClass and Gateway
 - Configuring HTTPRoute annotations for per-route origin settings
 - Multi-zone DNS configuration

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -8,6 +8,7 @@ App version: {{ .Chart.AppVersion }}
 CRDs installed:
   - cloudflaretunnels.cfgate.io
   - cloudflarednses.cfgate.io
+  - cloudflareaccessapplications.cfgate.io
   - cloudflareaccesspolicies.cfgate.io
 
 Note: CRDs have "helm.sh/resource-policy: keep" annotation and will not be
@@ -15,6 +16,7 @@ deleted when the chart is uninstalled. To remove CRDs manually:
 
   kubectl delete crd cloudflaretunnels.cfgate.io
   kubectl delete crd cloudflarednses.cfgate.io
+  kubectl delete crd cloudflareaccessapplications.cfgate.io
   kubectl delete crd cloudflareaccesspolicies.cfgate.io
 
 {{- end }}

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -50,6 +50,7 @@ rules:
 - apiGroups:
   - cfgate.io
   resources:
+  - cloudflareaccessapplications
   - cloudflareaccesspolicies
   - cloudflarednses
   - cloudflaretunnels
@@ -64,6 +65,7 @@ rules:
 - apiGroups:
   - cfgate.io
   resources:
+  - cloudflareaccessapplications/finalizers
   - cloudflareaccesspolicies/finalizers
   - cloudflarednses/finalizers
   - cloudflaretunnels/finalizers
@@ -72,6 +74,7 @@ rules:
 - apiGroups:
   - cfgate.io
   resources:
+  - cloudflareaccessapplications/status
   - cloudflareaccesspolicies/status
   - cloudflarednses/status
   - cloudflaretunnels/status

--- a/templates/crds/cloudflareaccessapplication.yaml
+++ b/templates/crds/cloudflareaccessapplication.yaml
@@ -1,0 +1,727 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: cloudflareaccessapplications.cfgate.io
+  labels:
+    {{- include "cfgate.labels" . | nindent 4 }}
+spec:
+  group: cfgate.io
+  names:
+    kind: CloudflareAccessApplication
+    listKind: CloudflareAccessApplicationList
+    plural: cloudflareaccessapplications
+    shortNames:
+    - cfaa
+    - cfaccessapp
+    singular: cloudflareaccessapplication
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.attachedTargets
+      name: Targets
+      type: integer
+    - jsonPath: .status.applications[0].id
+      name: Application
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CloudflareAccessApplication binds Gateway API targets to reusable
+          Cloudflare Access policies.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CloudflareAccessApplicationSpec defines Gateway API target
+              bindings to reusable Access policies.
+            properties:
+              application:
+                description: |-
+                  Application defines Access Application settings shared by generated apps.
+                  The path field overrides any path derived from HTTPRoute rules.
+                properties:
+                  allowedIdps:
+                    description: |-
+                      AllowedIdps restricts which identity providers can authenticate.
+                      Values are Cloudflare Identity Provider UUIDs.
+                      When empty, all IdPs configured in the account are allowed.
+                    items:
+                      type: string
+                    maxItems: 25
+                    type: array
+                  appLauncherVisible:
+                    default: true
+                    description: |-
+                      AppLauncherVisible controls whether the application appears in the
+                      Cloudflare App Launcher dashboard. Use pointer to distinguish
+                      explicit false (hidden) from absent (default visible).
+                    type: boolean
+                  autoRedirectToIdentity:
+                    description: |-
+                      AutoRedirectToIdentity auto-redirects to the identity provider
+                      when a single IdP is configured in allowedIdps. Skips the IdP
+                      selection page.
+                    type: boolean
+                  corsHeaders:
+                    description: |-
+                      CORSHeaders configures CORS for browser-based APIs behind Access.
+                      When set, Cloudflare responds to OPTIONS preflight on behalf of the origin.
+                      Mutually exclusive with optionsPreflightBypass.
+                    properties:
+                      allowAllHeaders:
+                        description: AllowAllHeaders allows all HTTP request headers.
+                        type: boolean
+                      allowAllMethods:
+                        description: AllowAllMethods allows all HTTP request methods.
+                        type: boolean
+                      allowAllOrigins:
+                        description: AllowAllOrigins allows all origins.
+                        type: boolean
+                      allowCredentials:
+                        description: |-
+                          AllowCredentials includes credentials (cookies, authorization headers,
+                          or TLS client certificates) with CORS requests.
+                        type: boolean
+                      allowedHeaders:
+                        description: |-
+                          AllowedHeaders lists specific allowed HTTP request headers.
+                          Ignored when allowAllHeaders is true.
+                        items:
+                          type: string
+                        maxItems: 50
+                        type: array
+                      allowedMethods:
+                        description: |-
+                          AllowedMethods lists specific allowed HTTP request methods.
+                          Ignored when allowAllMethods is true.
+                        items:
+                          description: CORSAllowedMethod is an HTTP method allowed
+                            for CORS requests.
+                          enum:
+                          - GET
+                          - POST
+                          - HEAD
+                          - PUT
+                          - DELETE
+                          - CONNECT
+                          - OPTIONS
+                          - TRACE
+                          - PATCH
+                          type: string
+                        maxItems: 9
+                        type: array
+                      allowedOrigins:
+                        description: |-
+                          AllowedOrigins lists specific allowed origins.
+                          Ignored when allowAllOrigins is true.
+                        items:
+                          type: string
+                        maxItems: 50
+                        type: array
+                      maxAge:
+                        description: MaxAge is the maximum number of seconds preflight
+                          results can be cached.
+                        maximum: 86400
+                        minimum: 0
+                        type: integer
+                    type: object
+                  customDenyMessage:
+                    description: CustomDenyMessage shown when access is denied.
+                    maxLength: 1024
+                    type: string
+                  customDenyUrl:
+                    description: CustomDenyURL redirects to this URL when denied (instead
+                      of message).
+                    type: string
+                  customNonIdentityDenyUrl:
+                    description: |-
+                      CustomNonIdentityDenyURL is the URL users are redirected to when
+                      denied by a non-identity (service auth) policy. Separate from
+                      customDenyUrl which handles identity-based denials.
+                    maxLength: 1024
+                    type: string
+                  domain:
+                    description: |-
+                      Domain is the protected domain (auto-generated from routes if omitted).
+                      Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: each DNS label must not exceed 63 octets (RFC 1035
+                        section 2.3.4)
+                      rule: self == '' || self.split('.').all(s, size(s) <= 63)
+                  enableBindingCookie:
+                    default: false
+                    description: EnableBindingCookie enables binding cookies for sticky
+                      sessions.
+                    type: boolean
+                  httpOnlyCookieAttribute:
+                    default: true
+                    description: HttpOnlyCookieAttribute adds HttpOnly to session
+                      cookies.
+                    type: boolean
+                  logoUrl:
+                    description: LogoURL is the application logo in dashboard.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: |-
+                      Name is the display name in Cloudflare dashboard.
+                      Defaults to CR name if omitted.
+                    maxLength: 255
+                    type: string
+                  optionsPreflightBypass:
+                    description: |-
+                      OptionsPreflightBypass allows OPTIONS preflight requests to bypass
+                      Access authentication and go directly to the origin. Enabling this
+                      removes all CORS header settings. Mutually exclusive with corsHeaders.
+                    type: boolean
+                  path:
+                    description: |-
+                      Path restricts protection to a specific absolute path prefix.
+                      Cloudflare Access paths must not include query strings or fragments.
+                    maxLength: 1024
+                    pattern: ^/[^?#]*$
+                    type: string
+                  pathCookieAttribute:
+                    description: |-
+                      PathCookieAttribute scopes the Access JWT cookie to the application
+                      path instead of the hostname. When enabled, users must re-authenticate
+                      for different paths on the same hostname.
+                    type: boolean
+                  readServiceTokensFromHeader:
+                    description: |-
+                      ReadServiceTokensFromHeader enables reading service tokens from a
+                      single custom HTTP header instead of the standard CF-Access-Client-Id
+                      and CF-Access-Client-Secret header pair. The value is the header name.
+                      The header value must contain a JSON object with "cf-access-client-id"
+                      and "cf-access-client-secret" keys.
+                    maxLength: 256
+                    type: string
+                  sameSiteCookieAttribute:
+                    default: lax
+                    description: SameSiteCookieAttribute controls cross-site cookie
+                      behavior.
+                    enum:
+                    - strict
+                    - lax
+                    - none
+                    type: string
+                  serviceAuth401Redirect:
+                    description: |-
+                      ServiceAuth401Redirect returns a 401 status code instead of
+                      redirecting to the Access login page when a request is blocked by a
+                      Service Auth (non_identity) policy. Enable for API consumers.
+                    type: boolean
+                  sessionDuration:
+                    default: 24h
+                    description: SessionDuration controls session cookie lifetime.
+                    pattern: ^([0-9]+(ns|us|ms|s|m|h))+$
+                    type: string
+                  skipInterstitial:
+                    default: false
+                    description: SkipInterstitial bypasses the Access login page for
+                      API requests.
+                    type: boolean
+                  type:
+                    default: self_hosted
+                    description: Type is the application type.
+                    enum:
+                    - self_hosted
+                    - saas
+                    - ssh
+                    - vnc
+                    - browser_isolation
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: corsHeaders and optionsPreflightBypass are mutually exclusive
+                  rule: '!(has(self.corsHeaders) && has(self.optionsPreflightBypass)
+                    && self.optionsPreflightBypass)'
+              cloudflareRef:
+                description: |-
+                  CloudflareRef references Cloudflare credentials. When omitted, credentials
+                  are inherited from each target's route -> Gateway -> CloudflareTunnel chain.
+                  Multiple targets must inherit the same Cloudflare account.
+                properties:
+                  accountId:
+                    description: AccountID is the Cloudflare account ID.
+                    maxLength: 32
+                    type: string
+                  accountName:
+                    description: AccountName is the Cloudflare account name (looked
+                      up via API).
+                    maxLength: 255
+                    type: string
+                  name:
+                    description: Name of the secret containing credentials.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace of the secret (defaults to policy namespace).
+                    type: string
+                required:
+                - name
+                type: object
+              policyRefs:
+                description: PolicyRefs lists reusable CloudflareAccessPolicy resources
+                  to attach.
+                items:
+                  description: AccessPolicyReference references a reusable CloudflareAccessPolicy.
+                  properties:
+                    name:
+                      description: Name is the CloudflareAccessPolicy name.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      default: ""
+                      description: |-
+                        Namespace is the CloudflareAccessPolicy namespace. Empty defaults to application namespace.
+                        Cross-namespace references require ReferenceGrant.
+                      maxLength: 253
+                      type: string
+                    precedence:
+                      description: |-
+                        Precedence determines policy evaluation order for the application. Lower values run first.
+                        When omitted, the controller uses list order starting at 1.
+                      maximum: 9999
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - namespace
+                x-kubernetes-list-type: map
+              targetRef:
+                description: TargetRef identifies a single Gateway API target.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the API group of the target resource.
+                    maxLength: 253
+                    type: string
+                  kind:
+                    description: Kind is the kind of the target resource.
+                    enum:
+                    - Gateway
+                    - HTTPRoute
+                    maxLength: 63
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the target resource.
+                      Cross-namespace targeting requires ReferenceGrant.
+                    maxLength: 253
+                    type: string
+                  sectionName:
+                    description: SectionName targets specific listener (Gateway) or
+                      rule (Route).
+                    maxLength: 253
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: group must be gateway.networking.k8s.io
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: kind must be Gateway or HTTPRoute
+                  rule: self.kind in ['Gateway', 'HTTPRoute']
+              targetRefs:
+                description: TargetRefs identifies multiple Gateway API targets.
+                items:
+                  description: |-
+                    PolicyTargetReference identifies a Gateway API resource for Access application attachment.
+
+                    PolicyTargetReference follows the Gateway API LocalPolicyTargetReferenceWithSectionName
+                    pattern. It targets Gateway API Gateway and HTTPRoute resources and extracts
+                    hostnames and paths from those resources to create corresponding Cloudflare Access
+                    applications.
+
+                    Cross-namespace references require a ReferenceGrant in the target namespace that permits
+                    CloudflareAccessApplication resources from the application's namespace.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: Group is the API group of the target resource.
+                      maxLength: 253
+                      type: string
+                    kind:
+                      description: Kind is the kind of the target resource.
+                      enum:
+                      - Gateway
+                      - HTTPRoute
+                      maxLength: 63
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the target resource.
+                        Cross-namespace targeting requires ReferenceGrant.
+                      maxLength: 253
+                      type: string
+                    sectionName:
+                      description: SectionName targets specific listener (Gateway)
+                        or rule (Route).
+                      maxLength: 253
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: group must be gateway.networking.k8s.io
+                    rule: self.group == 'gateway.networking.k8s.io'
+                  - message: kind must be Gateway or HTTPRoute
+                    rule: self.kind in ['Gateway', 'HTTPRoute']
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - policyRefs
+            type: object
+            x-kubernetes-validations:
+            - message: either targetRef or targetRefs must be specified
+              rule: has(self.targetRef) || has(self.targetRefs)
+            - message: targetRef and targetRefs are mutually exclusive
+              rule: '!(has(self.targetRef) && has(self.targetRefs))'
+            - message: policyRefs must either all omit precedence or all specify precedence
+              rule: self.policyRefs.all(p, !has(p.precedence)) || self.policyRefs.all(p,
+                has(p.precedence))
+            - message: policyRefs precedence values must be unique
+              rule: self.policyRefs.all(p, !has(p.precedence)) || self.policyRefs.all(p,
+                has(p.precedence) && self.policyRefs.exists_one(q, has(q.precedence)
+                && q.precedence == p.precedence))
+          status:
+            description: CloudflareAccessApplicationStatus defines observed Access
+              application state.
+            properties:
+              accountId:
+                description: AccountID is the resolved Cloudflare account ID used
+                  for Access application cleanup.
+                maxLength: 32
+                type: string
+              ancestors:
+                description: Ancestors contains status for each targetRef.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the policy attachment status for a specific target.
+
+                    PolicyAncestorStatus follows the Gateway API PolicyAncestorStatus pattern to report
+                    per-target attachment status. Each target reference in the spec has a corresponding
+                    ancestor status entry showing whether the policy was successfully attached.
+                  properties:
+                    ancestorRef:
+                      description: AncestorRef identifies the target.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: Group is the API group of the target resource.
+                          maxLength: 253
+                          type: string
+                        kind:
+                          description: Kind is the kind of the target resource.
+                          enum:
+                          - Gateway
+                          - HTTPRoute
+                          maxLength: 63
+                          type: string
+                        name:
+                          description: Name is the name of the target resource.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the target resource.
+                            Cross-namespace targeting requires ReferenceGrant.
+                          maxLength: 253
+                          type: string
+                        sectionName:
+                          description: SectionName targets specific listener (Gateway)
+                            or rule (Route).
+                          maxLength: 253
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-validations:
+                      - message: group must be gateway.networking.k8s.io
+                        rule: self.group == 'gateway.networking.k8s.io'
+                      - message: kind must be Gateway or HTTPRoute
+                        rule: self.kind in ['Gateway', 'HTTPRoute']
+                    conditions:
+                      description: Conditions for this specific target.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                    controllerName:
+                      description: ControllerName identifies the controller managing
+                        this attachment.
+                      maxLength: 253
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 64
+                type: array
+              applications:
+                description: Applications are Cloudflare Access Applications managed
+                  by this resource.
+                items:
+                  description: AccessApplicationObserved records a Cloudflare Access
+                    Application created for one host/path target.
+                  properties:
+                    aud:
+                      description: AUD is the Application Audience Tag.
+                      maxLength: 255
+                      type: string
+                    domain:
+                      description: Domain is the protected hostname/path in Cloudflare.
+                      maxLength: 1024
+                      type: string
+                    id:
+                      description: ID is the Cloudflare Access Application ID.
+                      maxLength: 36
+                      type: string
+                    targetRef:
+                      description: TargetRef identifies the Gateway API target that
+                        produced this application.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: Group is the API group of the target resource.
+                          maxLength: 253
+                          type: string
+                        kind:
+                          description: Kind is the kind of the target resource.
+                          enum:
+                          - Gateway
+                          - HTTPRoute
+                          maxLength: 63
+                          type: string
+                        name:
+                          description: Name is the name of the target resource.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the target resource.
+                            Cross-namespace targeting requires ReferenceGrant.
+                          maxLength: 253
+                          type: string
+                        sectionName:
+                          description: SectionName targets specific listener (Gateway)
+                            or rule (Route).
+                          maxLength: 253
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-validations:
+                      - message: group must be gateway.networking.k8s.io
+                        rule: self.group == 'gateway.networking.k8s.io'
+                      - message: kind must be Gateway or HTTPRoute
+                        rule: self.kind in ['Gateway', 'HTTPRoute']
+                  type: object
+                maxItems: 64
+                type: array
+              attachedTargets:
+                description: AttachedTargets is the count of successfully attached
+                  Gateway API targets.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions describe current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              credentialSecretRef:
+                description: |-
+                  CredentialSecretRef is the resolved credentials Secret used for cleanup.
+                  The namespace is always stored explicitly.
+                properties:
+                  name:
+                    description: Name of the secret.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace of the secret. Defaults to the resource's
+                      namespace if empty.
+                    maxLength: 63
+                    type: string
+                required:
+                - name
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the last generation processed.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/templates/crds/cloudflareaccesspolicy.yaml
+++ b/templates/crds/cloudflareaccesspolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: cloudflareaccesspolicies.cfgate.io
   labels:
@@ -25,11 +25,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
       type: string
-    - jsonPath: .status.applicationId
-      name: Application
+    - jsonPath: .status.policyId
+      name: Policy
       type: string
-    - jsonPath: .status.attachedTargets
-      name: Targets
+    - jsonPath: .status.appCount
+      name: Apps
       type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -40,9 +40,8 @@ spec:
         description: |-
           CloudflareAccessPolicy is the Schema for the cloudflareaccesspolicies API.
 
-          CloudflareAccessPolicy manages Cloudflare Access Applications and Policies for zero-trust
-          access control. It attaches to Gateway API Gateway and HTTPRoute resources using the
-          targetRefs pattern and creates corresponding Access Applications in Cloudflare.
+          CloudflareAccessPolicy manages a reusable account-level Cloudflare Access Policy.
+          CloudflareAccessApplication attaches reusable policies to Gateway API targets.
 
           Access rules are organized into implementation tiers based on IdP requirements:
             - P0: IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken (no IdP)
@@ -51,13 +50,10 @@ spec:
             - P3: not in current product scope (Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.)
 
           Status conditions:
-            - Ready: policy is fully applied to all targets
+            - Ready: policy is synced and service tokens are ready when configured
             - CredentialsValid: Cloudflare credentials have been validated
-            - TargetsResolved: all targetRefs have been found and validated
-            - ReferenceGrantValid: cross-namespace references are authorized
-            - ApplicationCreated: Access Application exists in Cloudflare
-            - PoliciesAttached: Access policies are attached to the application
             - ServiceTokensReady: all service tokens have been created
+            - PolicySynced: reusable Access policy exists in Cloudflare
         properties:
           apiVersion:
             description: |-
@@ -78,214 +74,49 @@ spec:
             type: object
           spec:
             description: |-
-              CloudflareAccessPolicySpec defines the desired state of a CloudflareAccessPolicy resource.
+              CloudflareAccessPolicySpec defines a reusable Cloudflare Access policy.
 
-              CloudflareAccessPolicySpec configures Cloudflare Access protection for Gateway API resources.
-              It specifies which resources to protect (via targetRef/targetRefs), the Access Application
-              settings, and the access policies that control who can access the protected hostnames.
+              CloudflareAccessPolicySpec manages account-level reusable Access policies. Applications
+              attach these policies through CloudflareAccessApplication policyRefs.
             properties:
-              application:
-                description: Application defines the Access Application settings.
-                properties:
-                  allowedIdps:
-                    description: |-
-                      AllowedIdps restricts which identity providers can authenticate.
-                      Values are Cloudflare Identity Provider UUIDs.
-                      When empty, all IdPs configured in the account are allowed.
-                    items:
+              approvalGroups:
+                description: ApprovalGroups defines who can approve access.
+                items:
+                  description: |-
+                    ApprovalGroup defines who can approve access requests for approval-required policies.
+
+                    ApprovalGroup specifies approvers by email address or email list UUID. When a
+                    policy requires approval, users matching this group can approve or deny access requests.
+                  properties:
+                    approvalsNeeded:
+                      default: 1
+                      description: ApprovalsNeeded is number of approvals required.
+                      minimum: 1
+                      type: integer
+                    emailListUuid:
+                      description: EmailListUUID is a Cloudflare Access email list
+                        UUID whose members can approve.
+                      maxLength: 36
                       type: string
-                    maxItems: 25
-                    type: array
-                  appLauncherVisible:
-                    default: true
-                    description: |-
-                      AppLauncherVisible controls whether the application appears in the
-                      Cloudflare App Launcher dashboard. Use pointer to distinguish
-                      explicit false (hidden) from absent (default visible).
-                    type: boolean
-                  autoRedirectToIdentity:
-                    description: |-
-                      AutoRedirectToIdentity auto-redirects to the identity provider
-                      when a single IdP is configured in allowedIdps. Skips the IdP
-                      selection page.
-                    type: boolean
-                  corsHeaders:
-                    description: |-
-                      CORSHeaders configures CORS for browser-based APIs behind Access.
-                      When set, Cloudflare responds to OPTIONS preflight on behalf of the origin.
-                      Mutually exclusive with optionsPreflightBypass.
-                    properties:
-                      allowAllHeaders:
-                        description: AllowAllHeaders allows all HTTP request headers.
-                        type: boolean
-                      allowAllMethods:
-                        description: AllowAllMethods allows all HTTP request methods.
-                        type: boolean
-                      allowAllOrigins:
-                        description: AllowAllOrigins allows all origins.
-                        type: boolean
-                      allowCredentials:
-                        description: |-
-                          AllowCredentials includes credentials (cookies, authorization headers,
-                          or TLS client certificates) with CORS requests.
-                        type: boolean
-                      allowedHeaders:
-                        description: |-
-                          AllowedHeaders lists specific allowed HTTP request headers.
-                          Ignored when allowAllHeaders is true.
-                        items:
-                          type: string
-                        maxItems: 50
-                        type: array
-                      allowedMethods:
-                        description: |-
-                          AllowedMethods lists specific allowed HTTP request methods.
-                          Ignored when allowAllMethods is true.
-                        items:
-                          description: CORSAllowedMethod is an HTTP method allowed
-                            for CORS requests.
-                          enum:
-                          - GET
-                          - POST
-                          - HEAD
-                          - PUT
-                          - DELETE
-                          - CONNECT
-                          - OPTIONS
-                          - TRACE
-                          - PATCH
-                          type: string
-                        maxItems: 9
-                        type: array
-                      allowedOrigins:
-                        description: |-
-                          AllowedOrigins lists specific allowed origins.
-                          Ignored when allowAllOrigins is true.
-                        items:
-                          type: string
-                        maxItems: 50
-                        type: array
-                      maxAge:
-                        description: MaxAge is the maximum number of seconds preflight
-                          results can be cached.
-                        maximum: 86400
-                        minimum: 0
-                        type: integer
-                    type: object
-                  customDenyMessage:
-                    description: CustomDenyMessage shown when access is denied.
-                    maxLength: 1024
-                    type: string
-                  customDenyUrl:
-                    description: CustomDenyURL redirects to this URL when denied (instead
-                      of message).
-                    type: string
-                  customNonIdentityDenyUrl:
-                    description: |-
-                      CustomNonIdentityDenyURL is the URL users are redirected to when
-                      denied by a non-identity (service auth) policy. Separate from
-                      customDenyUrl which handles identity-based denials.
-                    maxLength: 1024
-                    type: string
-                  domain:
-                    description: |-
-                      Domain is the protected domain (auto-generated from routes if omitted).
-                      Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
-                    maxLength: 253
-                    type: string
-                    x-kubernetes-validations:
-                    - message: each DNS label must not exceed 63 octets (RFC 1035
-                        section 2.3.4)
-                      rule: self == '' || self.split('.').all(s, size(s) <= 63)
-                  enableBindingCookie:
-                    default: false
-                    description: EnableBindingCookie enables binding cookies for sticky
-                      sessions.
-                    type: boolean
-                  httpOnlyCookieAttribute:
-                    default: true
-                    description: HttpOnlyCookieAttribute adds HttpOnly to session
-                      cookies.
-                    type: boolean
-                  logoUrl:
-                    description: LogoURL is the application logo in dashboard.
-                    maxLength: 1024
-                    type: string
-                  name:
-                    description: |-
-                      Name is the display name in Cloudflare dashboard.
-                      Defaults to CR name if omitted.
-                    maxLength: 255
-                    type: string
-                  optionsPreflightBypass:
-                    description: |-
-                      OptionsPreflightBypass allows OPTIONS preflight requests to bypass
-                      Access authentication and go directly to the origin. Enabling this
-                      removes all CORS header settings. Mutually exclusive with corsHeaders.
-                    type: boolean
-                  path:
-                    default: /
-                    description: Path restricts protection to specific path prefix.
-                    maxLength: 1024
-                    type: string
-                  pathCookieAttribute:
-                    description: |-
-                      PathCookieAttribute scopes the Access JWT cookie to the application
-                      path instead of the hostname. When enabled, users must re-authenticate
-                      for different paths on the same hostname.
-                    type: boolean
-                  readServiceTokensFromHeader:
-                    description: |-
-                      ReadServiceTokensFromHeader enables reading service tokens from a
-                      single custom HTTP header instead of the standard CF-Access-Client-Id
-                      and CF-Access-Client-Secret header pair. The value is the header name.
-                      The header value must contain a JSON object with "cf-access-client-id"
-                      and "cf-access-client-secret" keys.
-                    maxLength: 256
-                    type: string
-                  sameSiteCookieAttribute:
-                    default: lax
-                    description: SameSiteCookieAttribute controls cross-site cookie
-                      behavior.
-                    enum:
-                    - strict
-                    - lax
-                    - none
-                    type: string
-                  serviceAuth401Redirect:
-                    description: |-
-                      ServiceAuth401Redirect returns a 401 status code instead of
-                      redirecting to the Access login page when a request is blocked by a
-                      Service Auth (non_identity) policy. Enable for API consumers.
-                    type: boolean
-                  sessionDuration:
-                    default: 24h
-                    description: SessionDuration controls session cookie lifetime.
-                    pattern: ^[0-9]+(h|m|s)$
-                    type: string
-                  skipInterstitial:
-                    default: false
-                    description: SkipInterstitial bypasses the Access login page for
-                      API requests.
-                    type: boolean
-                  type:
-                    default: self_hosted
-                    description: Type is the application type.
-                    enum:
-                    - self_hosted
-                    - saas
-                    - ssh
-                    - vnc
-                    - browser_isolation
-                    type: string
-                type: object
-                x-kubernetes-validations:
-                - message: corsHeaders and optionsPreflightBypass are mutually exclusive
-                  rule: '!(has(self.corsHeaders) && has(self.optionsPreflightBypass)
-                    && self.optionsPreflightBypass)'
+                    emails:
+                      description: Emails of approvers.
+                      items:
+                        type: string
+                      maxItems: 50
+                      type: array
+                  type: object
+                  x-kubernetes-validations:
+                  - message: at least one approver (emails or emailListUuid) must
+                      be specified
+                    rule: (has(self.emails) && size(self.emails) > 0) || has(self.emailListUuid)
+                maxItems: 10
+                type: array
+              approvalRequired:
+                default: false
+                description: ApprovalRequired requires approval from specific users.
+                type: boolean
               cloudflareRef:
-                description: CloudflareRef references Cloudflare credentials (inherits
-                  from tunnel if omitted).
+                description: CloudflareRef references Cloudflare credentials.
                 properties:
                   accountId:
                     description: AccountID is the Cloudflare account ID.
@@ -307,698 +138,647 @@ spec:
                 required:
                 - name
                 type: object
-              groupRefs:
-                description: GroupRefs reference reusable identity rules.
+              decision:
+                default: allow
+                description: Decision is the policy action.
+                enum:
+                - allow
+                - deny
+                - bypass
+                - non_identity
+                type: string
+              exclude:
+                description: Exclude rules (if ANY match, policy does not apply).
                 items:
                   description: |-
-                    AccessGroupRef references a Cloudflare Access Group.
+                    AccessRule defines identity matching criteria for Access policies.
 
-                    AccessGroupRef enables referencing reusable identity rules defined as Access Groups
-                    in Cloudflare. Groups can be referenced by Kubernetes CR name (future feature) or
-                    by Cloudflare ID.
+                    AccessRule specifies conditions that identify users or services. Rules are organized
+                    into implementation tiers based on IdP requirements:
+                      - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
+                      - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
+                      - P2 (Google Workspace): GSuiteGroup
+                      - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
+
+                    SDK types map directly to cloudflare-go v6 SDK: IPRule, IPListRule, CountryRule,
+                    EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
+                    EmailListRule, AccessOIDCClaimRule, GSuiteGroupRule.
                   properties:
-                    cloudflareId:
-                      description: CloudflareID of group in Cloudflare (bypasses CR
-                        lookup).
-                      maxLength: 36
-                      type: string
-                    name:
-                      description: Name of AccessGroup CR in same namespace.
-                      maxLength: 253
-                      type: string
-                  type: object
-                  x-kubernetes-validations:
-                  - message: either name or cloudflareId must be specified
-                    rule: has(self.name) || has(self.cloudflareId)
-                maxItems: 50
-                type: array
-              policies:
-                description: Policies define access rules (evaluated in order).
-                items:
-                  description: |-
-                    AccessPolicyRule defines an access allow, deny, bypass, or non_identity rule.
-
-                    AccessPolicyRule specifies who can access the protected application. Rules are evaluated
-                    in precedence order (lower precedence = higher priority). Each rule contains Include
-                    (ANY must match), Exclude (if ANY match, rule does not apply), and Require (ALL must match)
-                    conditions.
-                  properties:
-                    approvalGroups:
-                      description: ApprovalGroups defines who can approve access.
-                      items:
-                        description: |-
-                          ApprovalGroup defines who can approve access requests for approval-required policies.
-
-                          ApprovalGroup specifies approvers by email address or email domain. When a policy
-                          requires approval, users matching this group can approve or deny access requests.
-                        properties:
-                          approvalsNeeded:
-                            default: 1
-                            description: ApprovalsNeeded is number of approvals required.
-                            minimum: 1
-                            type: integer
-                          emailDomain:
-                            description: |-
-                              EmailDomain allows any user from domain to approve.
-                              Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
-                            maxLength: 253
+                    anyValidServiceToken:
+                      description: |-
+                        AnyValidServiceToken matches any valid service token.
+                        SDK: AnyValidServiceTokenRule
+                      type: boolean
+                    country:
+                      description: |-
+                        Country matches source country codes (ISO 3166-1 alpha-2).
+                        SDK: CountryRule
+                      properties:
+                        codes:
+                          description: Codes are ISO 3166-1 alpha-2 country codes.
+                          items:
                             type: string
-                          emails:
-                            description: Emails of approvers.
-                            items:
-                              type: string
-                            maxItems: 50
-                            type: array
-                        type: object
-                        x-kubernetes-validations:
-                        - message: at least one approver (emails or emailDomain) must
-                            be specified
-                          rule: size(self.emails) > 0 || has(self.emailDomain)
-                      maxItems: 10
-                      type: array
-                    approvalRequired:
-                      default: false
-                      description: ApprovalRequired requires approval from specific
-                        users.
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - codes
+                      type: object
+                    email:
+                      description: |-
+                        Email matches specific email addresses.
+                        SDK: EmailRule
+                      properties:
+                        addresses:
+                          description: Addresses to match.
+                          items:
+                            type: string
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - addresses
+                      type: object
+                    emailDomain:
+                      description: |-
+                        EmailDomain matches email domain suffix.
+                        SDK: DomainRule
+                      properties:
+                        domain:
+                          description: |-
+                            Domain suffix (e.g., "example.com").
+                            Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - domain
+                      type: object
+                    emailList:
+                      description: |-
+                        EmailList references a Cloudflare Access email list.
+                        SDK: EmailListRule
+                      properties:
+                        id:
+                          description: ID of the Access list in Cloudflare.
+                          maxLength: 36
+                          type: string
+                        name:
+                          description: Name of the Access list (looked up via API).
+                          maxLength: 255
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either id or name must be specified
+                        rule: has(self.id) || has(self.name)
+                    everyone:
+                      description: |-
+                        Everyone matches all users (use with caution).
+                        SDK: EveryoneRule
                       type: boolean
-                    decision:
-                      default: allow
-                      description: Decision is the policy action.
-                      enum:
-                      - allow
-                      - deny
-                      - bypass
-                      - non_identity
-                      type: string
-                    exclude:
-                      description: Exclude rules (if ANY match, rule does not apply).
-                      items:
-                        description: |-
-                          AccessRule defines identity matching criteria for Access policies.
-
-                          AccessRule specifies conditions that identify users or services. Rules are organized
-                          into implementation tiers based on IdP requirements:
-                            - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
-                            - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
-                            - P2 (Google Workspace): GSuiteGroup
-                            - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
-
-                          SDK types map directly to cloudflare-go v6.6.0: IPRule, IPListRule, CountryRule,
-                          EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
-                          EmailListRule, AccessOIDCClaimRule, GSuiteGroupRule.
-                        properties:
-                          anyValidServiceToken:
-                            description: |-
-                              AnyValidServiceToken matches any valid service token.
-                              SDK: AnyValidServiceTokenRule
-                            type: boolean
-                          country:
-                            description: |-
-                              Country matches source country codes (ISO 3166-1 alpha-2).
-                              SDK: CountryRule
-                            properties:
-                              codes:
-                                description: Codes are ISO 3166-1 alpha-2 country
-                                  codes.
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - codes
-                            type: object
-                          email:
-                            description: |-
-                              Email matches specific email addresses.
-                              SDK: EmailRule
-                            properties:
-                              addresses:
-                                description: Addresses to match.
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - addresses
-                            type: object
-                          emailDomain:
-                            description: |-
-                              EmailDomain matches email domain suffix.
-                              SDK: DomainRule
-                            properties:
-                              domain:
-                                description: |-
-                                  Domain suffix (e.g., "example.com").
-                                  Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                            required:
-                            - domain
-                            type: object
-                          emailList:
-                            description: |-
-                              EmailList references a Cloudflare Access email list.
-                              SDK: EmailListRule
-                            properties:
-                              id:
-                                description: ID of the Access list in Cloudflare.
-                                maxLength: 36
-                                type: string
-                              name:
-                                description: Name of the Access list (looked up via
-                                  API).
-                                maxLength: 255
-                                type: string
-                            type: object
-                            x-kubernetes-validations:
-                            - message: either id or name must be specified
-                              rule: has(self.id) || has(self.name)
-                          everyone:
-                            description: |-
-                              Everyone matches all users (use with caution).
-                              SDK: EveryoneRule
-                            type: boolean
-                          gsuiteGroup:
-                            description: |-
-                              GSuiteGroup matches Google Workspace groups.
-                              SDK: GSuiteGroupRule
-                            properties:
-                              email:
-                                description: Email is the Google Workspace group email.
-                                maxLength: 320
-                                minLength: 1
-                                type: string
-                              identityProviderId:
-                                description: IdentityProviderID in Cloudflare.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - email
-                            - identityProviderId
-                            type: object
-                          ip:
-                            description: |-
-                              IP matches source IP CIDR ranges.
-                              SDK: IPRule
-                            properties:
-                              ranges:
-                                description: Ranges are CIDR blocks (IPv4 or IPv6).
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - ranges
-                            type: object
-                          ipList:
-                            description: |-
-                              IPList references a Cloudflare IP List.
-                              SDK: IPListRule
-                            properties:
-                              id:
-                                description: ID of the IP list in Cloudflare.
-                                maxLength: 36
-                                type: string
-                              name:
-                                description: Name of the IP list (looked up via API).
-                                maxLength: 255
-                                type: string
-                            type: object
-                            x-kubernetes-validations:
-                            - message: either id or name must be specified
-                              rule: has(self.id) || has(self.name)
-                          oidcClaim:
-                            description: |-
-                              OIDCClaim matches OIDC token claims.
-                              SDK: AccessOIDCClaimRule
-                            properties:
-                              claimName:
-                                description: ClaimName is the OIDC claim to match.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              claimValue:
-                                description: ClaimValue is the expected value.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              identityProviderId:
-                                description: IdentityProviderID in Cloudflare.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - claimName
-                            - claimValue
-                            - identityProviderId
-                            type: object
-                          serviceToken:
-                            description: |-
-                              ServiceToken matches a specific service token by ID.
-                              SDK: ServiceTokenRule
-                            properties:
-                              tokenId:
-                                description: TokenID is the Cloudflare service token
-                                  ID.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - tokenId
-                            type: object
-                        type: object
-                        x-kubernetes-validations:
-                        - message: at least one rule type must be specified
-                          rule: '[has(self.ip), has(self.ipList), has(self.country),
-                            has(self.everyone), has(self.serviceToken), has(self.anyValidServiceToken),
-                            has(self.email), has(self.emailList), has(self.emailDomain),
-                            has(self.oidcClaim), has(self.gsuiteGroup)].exists(x,
-                            x)'
-                      maxItems: 25
-                      type: array
-                    include:
-                      description: Include rules (ANY must match for rule to apply).
-                      items:
-                        description: |-
-                          AccessRule defines identity matching criteria for Access policies.
-
-                          AccessRule specifies conditions that identify users or services. Rules are organized
-                          into implementation tiers based on IdP requirements:
-                            - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
-                            - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
-                            - P2 (Google Workspace): GSuiteGroup
-                            - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
-
-                          SDK types map directly to cloudflare-go v6.6.0: IPRule, IPListRule, CountryRule,
-                          EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
-                          EmailListRule, AccessOIDCClaimRule, GSuiteGroupRule.
-                        properties:
-                          anyValidServiceToken:
-                            description: |-
-                              AnyValidServiceToken matches any valid service token.
-                              SDK: AnyValidServiceTokenRule
-                            type: boolean
-                          country:
-                            description: |-
-                              Country matches source country codes (ISO 3166-1 alpha-2).
-                              SDK: CountryRule
-                            properties:
-                              codes:
-                                description: Codes are ISO 3166-1 alpha-2 country
-                                  codes.
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - codes
-                            type: object
-                          email:
-                            description: |-
-                              Email matches specific email addresses.
-                              SDK: EmailRule
-                            properties:
-                              addresses:
-                                description: Addresses to match.
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - addresses
-                            type: object
-                          emailDomain:
-                            description: |-
-                              EmailDomain matches email domain suffix.
-                              SDK: DomainRule
-                            properties:
-                              domain:
-                                description: |-
-                                  Domain suffix (e.g., "example.com").
-                                  Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                            required:
-                            - domain
-                            type: object
-                          emailList:
-                            description: |-
-                              EmailList references a Cloudflare Access email list.
-                              SDK: EmailListRule
-                            properties:
-                              id:
-                                description: ID of the Access list in Cloudflare.
-                                maxLength: 36
-                                type: string
-                              name:
-                                description: Name of the Access list (looked up via
-                                  API).
-                                maxLength: 255
-                                type: string
-                            type: object
-                            x-kubernetes-validations:
-                            - message: either id or name must be specified
-                              rule: has(self.id) || has(self.name)
-                          everyone:
-                            description: |-
-                              Everyone matches all users (use with caution).
-                              SDK: EveryoneRule
-                            type: boolean
-                          gsuiteGroup:
-                            description: |-
-                              GSuiteGroup matches Google Workspace groups.
-                              SDK: GSuiteGroupRule
-                            properties:
-                              email:
-                                description: Email is the Google Workspace group email.
-                                maxLength: 320
-                                minLength: 1
-                                type: string
-                              identityProviderId:
-                                description: IdentityProviderID in Cloudflare.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - email
-                            - identityProviderId
-                            type: object
-                          ip:
-                            description: |-
-                              IP matches source IP CIDR ranges.
-                              SDK: IPRule
-                            properties:
-                              ranges:
-                                description: Ranges are CIDR blocks (IPv4 or IPv6).
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - ranges
-                            type: object
-                          ipList:
-                            description: |-
-                              IPList references a Cloudflare IP List.
-                              SDK: IPListRule
-                            properties:
-                              id:
-                                description: ID of the IP list in Cloudflare.
-                                maxLength: 36
-                                type: string
-                              name:
-                                description: Name of the IP list (looked up via API).
-                                maxLength: 255
-                                type: string
-                            type: object
-                            x-kubernetes-validations:
-                            - message: either id or name must be specified
-                              rule: has(self.id) || has(self.name)
-                          oidcClaim:
-                            description: |-
-                              OIDCClaim matches OIDC token claims.
-                              SDK: AccessOIDCClaimRule
-                            properties:
-                              claimName:
-                                description: ClaimName is the OIDC claim to match.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              claimValue:
-                                description: ClaimValue is the expected value.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              identityProviderId:
-                                description: IdentityProviderID in Cloudflare.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - claimName
-                            - claimValue
-                            - identityProviderId
-                            type: object
-                          serviceToken:
-                            description: |-
-                              ServiceToken matches a specific service token by ID.
-                              SDK: ServiceTokenRule
-                            properties:
-                              tokenId:
-                                description: TokenID is the Cloudflare service token
-                                  ID.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - tokenId
-                            type: object
-                        type: object
-                        x-kubernetes-validations:
-                        - message: at least one rule type must be specified
-                          rule: '[has(self.ip), has(self.ipList), has(self.country),
-                            has(self.everyone), has(self.serviceToken), has(self.anyValidServiceToken),
-                            has(self.email), has(self.emailList), has(self.emailDomain),
-                            has(self.oidcClaim), has(self.gsuiteGroup)].exists(x,
-                            x)'
-                      maxItems: 25
-                      type: array
-                    name:
-                      description: Name is a human-readable identifier.
-                      maxLength: 255
-                      minLength: 1
-                      type: string
-                    precedence:
-                      description: Precedence determines rule evaluation order (lower
-                        = first).
-                      maximum: 9999
-                      minimum: 1
-                      type: integer
-                    purposeJustificationPrompt:
-                      description: PurposeJustificationPrompt is the prompt shown
-                        to user.
-                      maxLength: 1024
-                      type: string
-                    purposeJustificationRequired:
-                      default: false
-                      description: PurposeJustificationRequired requires user to provide
-                        justification.
-                      type: boolean
-                    require:
-                      description: Require rules (ALL must match for rule to apply).
-                      items:
-                        description: |-
-                          AccessRule defines identity matching criteria for Access policies.
-
-                          AccessRule specifies conditions that identify users or services. Rules are organized
-                          into implementation tiers based on IdP requirements:
-                            - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
-                            - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
-                            - P2 (Google Workspace): GSuiteGroup
-                            - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
-
-                          SDK types map directly to cloudflare-go v6.6.0: IPRule, IPListRule, CountryRule,
-                          EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
-                          EmailListRule, AccessOIDCClaimRule, GSuiteGroupRule.
-                        properties:
-                          anyValidServiceToken:
-                            description: |-
-                              AnyValidServiceToken matches any valid service token.
-                              SDK: AnyValidServiceTokenRule
-                            type: boolean
-                          country:
-                            description: |-
-                              Country matches source country codes (ISO 3166-1 alpha-2).
-                              SDK: CountryRule
-                            properties:
-                              codes:
-                                description: Codes are ISO 3166-1 alpha-2 country
-                                  codes.
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - codes
-                            type: object
-                          email:
-                            description: |-
-                              Email matches specific email addresses.
-                              SDK: EmailRule
-                            properties:
-                              addresses:
-                                description: Addresses to match.
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - addresses
-                            type: object
-                          emailDomain:
-                            description: |-
-                              EmailDomain matches email domain suffix.
-                              SDK: DomainRule
-                            properties:
-                              domain:
-                                description: |-
-                                  Domain suffix (e.g., "example.com").
-                                  Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                            required:
-                            - domain
-                            type: object
-                          emailList:
-                            description: |-
-                              EmailList references a Cloudflare Access email list.
-                              SDK: EmailListRule
-                            properties:
-                              id:
-                                description: ID of the Access list in Cloudflare.
-                                maxLength: 36
-                                type: string
-                              name:
-                                description: Name of the Access list (looked up via
-                                  API).
-                                maxLength: 255
-                                type: string
-                            type: object
-                            x-kubernetes-validations:
-                            - message: either id or name must be specified
-                              rule: has(self.id) || has(self.name)
-                          everyone:
-                            description: |-
-                              Everyone matches all users (use with caution).
-                              SDK: EveryoneRule
-                            type: boolean
-                          gsuiteGroup:
-                            description: |-
-                              GSuiteGroup matches Google Workspace groups.
-                              SDK: GSuiteGroupRule
-                            properties:
-                              email:
-                                description: Email is the Google Workspace group email.
-                                maxLength: 320
-                                minLength: 1
-                                type: string
-                              identityProviderId:
-                                description: IdentityProviderID in Cloudflare.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - email
-                            - identityProviderId
-                            type: object
-                          ip:
-                            description: |-
-                              IP matches source IP CIDR ranges.
-                              SDK: IPRule
-                            properties:
-                              ranges:
-                                description: Ranges are CIDR blocks (IPv4 or IPv6).
-                                items:
-                                  type: string
-                                maxItems: 50
-                                minItems: 1
-                                type: array
-                            required:
-                            - ranges
-                            type: object
-                          ipList:
-                            description: |-
-                              IPList references a Cloudflare IP List.
-                              SDK: IPListRule
-                            properties:
-                              id:
-                                description: ID of the IP list in Cloudflare.
-                                maxLength: 36
-                                type: string
-                              name:
-                                description: Name of the IP list (looked up via API).
-                                maxLength: 255
-                                type: string
-                            type: object
-                            x-kubernetes-validations:
-                            - message: either id or name must be specified
-                              rule: has(self.id) || has(self.name)
-                          oidcClaim:
-                            description: |-
-                              OIDCClaim matches OIDC token claims.
-                              SDK: AccessOIDCClaimRule
-                            properties:
-                              claimName:
-                                description: ClaimName is the OIDC claim to match.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              claimValue:
-                                description: ClaimValue is the expected value.
-                                maxLength: 255
-                                minLength: 1
-                                type: string
-                              identityProviderId:
-                                description: IdentityProviderID in Cloudflare.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - claimName
-                            - claimValue
-                            - identityProviderId
-                            type: object
-                          serviceToken:
-                            description: |-
-                              ServiceToken matches a specific service token by ID.
-                              SDK: ServiceTokenRule
-                            properties:
-                              tokenId:
-                                description: TokenID is the Cloudflare service token
-                                  ID.
-                                maxLength: 36
-                                minLength: 1
-                                type: string
-                            required:
-                            - tokenId
-                            type: object
-                        type: object
-                        x-kubernetes-validations:
-                        - message: at least one rule type must be specified
-                          rule: '[has(self.ip), has(self.ipList), has(self.country),
-                            has(self.everyone), has(self.serviceToken), has(self.anyValidServiceToken),
-                            has(self.email), has(self.emailList), has(self.emailDomain),
-                            has(self.oidcClaim), has(self.gsuiteGroup)].exists(x,
-                            x)'
-                      maxItems: 25
-                      type: array
-                    sessionDuration:
-                      description: SessionDuration overrides application session duration
-                        for this rule.
-                      maxLength: 10
-                      pattern: ^[0-9]+(h|m|s)$
-                      type: string
-                  required:
-                  - decision
-                  - name
+                    group:
+                      description: |-
+                        Group matches a Cloudflare Access Group by ID.
+                        SDK: GroupRule
+                      properties:
+                        id:
+                          description: ID is the Cloudflare Access Group ID.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - id
+                      type: object
+                    gsuiteGroup:
+                      description: |-
+                        GSuiteGroup matches Google Workspace groups.
+                        SDK: GSuiteGroupRule
+                      properties:
+                        email:
+                          description: Email is the Google Workspace group email.
+                          maxLength: 320
+                          minLength: 1
+                          type: string
+                        identityProviderId:
+                          description: IdentityProviderID in Cloudflare.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - email
+                      - identityProviderId
+                      type: object
+                    ip:
+                      description: |-
+                        IP matches source IP CIDR ranges.
+                        SDK: IPRule
+                      properties:
+                        ranges:
+                          description: Ranges are CIDR blocks (IPv4 or IPv6).
+                          items:
+                            type: string
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - ranges
+                      type: object
+                    ipList:
+                      description: |-
+                        IPList references a Cloudflare IP List.
+                        SDK: IPListRule
+                      properties:
+                        id:
+                          description: ID of the IP list in Cloudflare.
+                          maxLength: 36
+                          type: string
+                        name:
+                          description: Name of the IP list (looked up via API).
+                          maxLength: 255
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either id or name must be specified
+                        rule: has(self.id) || has(self.name)
+                    oidcClaim:
+                      description: |-
+                        OIDCClaim matches OIDC token claims.
+                        SDK: AccessOIDCClaimRule
+                      properties:
+                        claimName:
+                          description: ClaimName is the OIDC claim to match.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        claimValue:
+                          description: ClaimValue is the expected value.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        identityProviderId:
+                          description: IdentityProviderID in Cloudflare.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - claimName
+                      - claimValue
+                      - identityProviderId
+                      type: object
+                    serviceToken:
+                      description: |-
+                        ServiceToken matches a specific service token by ID.
+                        SDK: ServiceTokenRule
+                      properties:
+                        name:
+                          description: |-
+                            Name references an entry in spec.serviceTokens. The controller replaces it
+                            with the created Cloudflare service token ID during policy sync.
+                          maxLength: 255
+                          type: string
+                        tokenId:
+                          description: TokenID is the Cloudflare service token ID.
+                          maxLength: 36
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either tokenId or name must be specified
+                        rule: has(self.tokenId) || has(self.name)
                   type: object
                   x-kubernetes-validations:
-                  - message: include rules are required for allow and deny decisions
-                    rule: self.decision in ['bypass', 'non_identity'] || size(self.include)
-                      > 0
-                maxItems: 50
+                  - message: at least one rule type must be specified
+                    rule: '[has(self.ip), has(self.ipList), has(self.country), has(self.everyone),
+                      has(self.serviceToken), has(self.anyValidServiceToken), has(self.email),
+                      has(self.emailList), has(self.emailDomain), has(self.oidcClaim),
+                      has(self.gsuiteGroup), has(self.group)].exists(x, x)'
+                maxItems: 25
+                type: array
+              include:
+                description: Include rules (ANY must match for policy to apply).
+                items:
+                  description: |-
+                    AccessRule defines identity matching criteria for Access policies.
+
+                    AccessRule specifies conditions that identify users or services. Rules are organized
+                    into implementation tiers based on IdP requirements:
+                      - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
+                      - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
+                      - P2 (Google Workspace): GSuiteGroup
+                      - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
+
+                    SDK types map directly to cloudflare-go v6 SDK: IPRule, IPListRule, CountryRule,
+                    EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
+                    EmailListRule, AccessOIDCClaimRule, GSuiteGroupRule.
+                  properties:
+                    anyValidServiceToken:
+                      description: |-
+                        AnyValidServiceToken matches any valid service token.
+                        SDK: AnyValidServiceTokenRule
+                      type: boolean
+                    country:
+                      description: |-
+                        Country matches source country codes (ISO 3166-1 alpha-2).
+                        SDK: CountryRule
+                      properties:
+                        codes:
+                          description: Codes are ISO 3166-1 alpha-2 country codes.
+                          items:
+                            type: string
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - codes
+                      type: object
+                    email:
+                      description: |-
+                        Email matches specific email addresses.
+                        SDK: EmailRule
+                      properties:
+                        addresses:
+                          description: Addresses to match.
+                          items:
+                            type: string
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - addresses
+                      type: object
+                    emailDomain:
+                      description: |-
+                        EmailDomain matches email domain suffix.
+                        SDK: DomainRule
+                      properties:
+                        domain:
+                          description: |-
+                            Domain suffix (e.g., "example.com").
+                            Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - domain
+                      type: object
+                    emailList:
+                      description: |-
+                        EmailList references a Cloudflare Access email list.
+                        SDK: EmailListRule
+                      properties:
+                        id:
+                          description: ID of the Access list in Cloudflare.
+                          maxLength: 36
+                          type: string
+                        name:
+                          description: Name of the Access list (looked up via API).
+                          maxLength: 255
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either id or name must be specified
+                        rule: has(self.id) || has(self.name)
+                    everyone:
+                      description: |-
+                        Everyone matches all users (use with caution).
+                        SDK: EveryoneRule
+                      type: boolean
+                    group:
+                      description: |-
+                        Group matches a Cloudflare Access Group by ID.
+                        SDK: GroupRule
+                      properties:
+                        id:
+                          description: ID is the Cloudflare Access Group ID.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - id
+                      type: object
+                    gsuiteGroup:
+                      description: |-
+                        GSuiteGroup matches Google Workspace groups.
+                        SDK: GSuiteGroupRule
+                      properties:
+                        email:
+                          description: Email is the Google Workspace group email.
+                          maxLength: 320
+                          minLength: 1
+                          type: string
+                        identityProviderId:
+                          description: IdentityProviderID in Cloudflare.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - email
+                      - identityProviderId
+                      type: object
+                    ip:
+                      description: |-
+                        IP matches source IP CIDR ranges.
+                        SDK: IPRule
+                      properties:
+                        ranges:
+                          description: Ranges are CIDR blocks (IPv4 or IPv6).
+                          items:
+                            type: string
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - ranges
+                      type: object
+                    ipList:
+                      description: |-
+                        IPList references a Cloudflare IP List.
+                        SDK: IPListRule
+                      properties:
+                        id:
+                          description: ID of the IP list in Cloudflare.
+                          maxLength: 36
+                          type: string
+                        name:
+                          description: Name of the IP list (looked up via API).
+                          maxLength: 255
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either id or name must be specified
+                        rule: has(self.id) || has(self.name)
+                    oidcClaim:
+                      description: |-
+                        OIDCClaim matches OIDC token claims.
+                        SDK: AccessOIDCClaimRule
+                      properties:
+                        claimName:
+                          description: ClaimName is the OIDC claim to match.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        claimValue:
+                          description: ClaimValue is the expected value.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        identityProviderId:
+                          description: IdentityProviderID in Cloudflare.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - claimName
+                      - claimValue
+                      - identityProviderId
+                      type: object
+                    serviceToken:
+                      description: |-
+                        ServiceToken matches a specific service token by ID.
+                        SDK: ServiceTokenRule
+                      properties:
+                        name:
+                          description: |-
+                            Name references an entry in spec.serviceTokens. The controller replaces it
+                            with the created Cloudflare service token ID during policy sync.
+                          maxLength: 255
+                          type: string
+                        tokenId:
+                          description: TokenID is the Cloudflare service token ID.
+                          maxLength: 36
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either tokenId or name must be specified
+                        rule: has(self.tokenId) || has(self.name)
+                  type: object
+                  x-kubernetes-validations:
+                  - message: at least one rule type must be specified
+                    rule: '[has(self.ip), has(self.ipList), has(self.country), has(self.everyone),
+                      has(self.serviceToken), has(self.anyValidServiceToken), has(self.email),
+                      has(self.emailList), has(self.emailDomain), has(self.oidcClaim),
+                      has(self.gsuiteGroup), has(self.group)].exists(x, x)'
+                maxItems: 25
+                minItems: 1
+                type: array
+              name:
+                description: Name is the Cloudflare Access policy display name.
+                maxLength: 255
+                minLength: 1
+                type: string
+              purposeJustificationPrompt:
+                description: PurposeJustificationPrompt is the prompt shown to user.
+                maxLength: 1024
+                type: string
+              purposeJustificationRequired:
+                default: false
+                description: PurposeJustificationRequired requires user to provide
+                  justification.
+                type: boolean
+              require:
+                description: Require rules (ALL must match for policy to apply).
+                items:
+                  description: |-
+                    AccessRule defines identity matching criteria for Access policies.
+
+                    AccessRule specifies conditions that identify users or services. Rules are organized
+                    into implementation tiers based on IdP requirements:
+                      - P0 (no IdP): IP, IPList, Country, Everyone, ServiceToken, AnyValidServiceToken
+                      - P1 (basic IdP): Email, EmailList, EmailDomain, OIDCClaim
+                      - P2 (Google Workspace): GSuiteGroup
+                      - P3 (not in current product scope): Certificate, CommonName, Group, GitHub, Azure, Okta, SAML, etc.
+
+                    SDK types map directly to cloudflare-go v6 SDK: IPRule, IPListRule, CountryRule,
+                    EveryoneRule, ServiceTokenRule, AnyValidServiceTokenRule, EmailRule, DomainRule,
+                    EmailListRule, AccessOIDCClaimRule, GSuiteGroupRule.
+                  properties:
+                    anyValidServiceToken:
+                      description: |-
+                        AnyValidServiceToken matches any valid service token.
+                        SDK: AnyValidServiceTokenRule
+                      type: boolean
+                    country:
+                      description: |-
+                        Country matches source country codes (ISO 3166-1 alpha-2).
+                        SDK: CountryRule
+                      properties:
+                        codes:
+                          description: Codes are ISO 3166-1 alpha-2 country codes.
+                          items:
+                            type: string
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - codes
+                      type: object
+                    email:
+                      description: |-
+                        Email matches specific email addresses.
+                        SDK: EmailRule
+                      properties:
+                        addresses:
+                          description: Addresses to match.
+                          items:
+                            type: string
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - addresses
+                      type: object
+                    emailDomain:
+                      description: |-
+                        EmailDomain matches email domain suffix.
+                        SDK: DomainRule
+                      properties:
+                        domain:
+                          description: |-
+                            Domain suffix (e.g., "example.com").
+                            Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - domain
+                      type: object
+                    emailList:
+                      description: |-
+                        EmailList references a Cloudflare Access email list.
+                        SDK: EmailListRule
+                      properties:
+                        id:
+                          description: ID of the Access list in Cloudflare.
+                          maxLength: 36
+                          type: string
+                        name:
+                          description: Name of the Access list (looked up via API).
+                          maxLength: 255
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either id or name must be specified
+                        rule: has(self.id) || has(self.name)
+                    everyone:
+                      description: |-
+                        Everyone matches all users (use with caution).
+                        SDK: EveryoneRule
+                      type: boolean
+                    group:
+                      description: |-
+                        Group matches a Cloudflare Access Group by ID.
+                        SDK: GroupRule
+                      properties:
+                        id:
+                          description: ID is the Cloudflare Access Group ID.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - id
+                      type: object
+                    gsuiteGroup:
+                      description: |-
+                        GSuiteGroup matches Google Workspace groups.
+                        SDK: GSuiteGroupRule
+                      properties:
+                        email:
+                          description: Email is the Google Workspace group email.
+                          maxLength: 320
+                          minLength: 1
+                          type: string
+                        identityProviderId:
+                          description: IdentityProviderID in Cloudflare.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - email
+                      - identityProviderId
+                      type: object
+                    ip:
+                      description: |-
+                        IP matches source IP CIDR ranges.
+                        SDK: IPRule
+                      properties:
+                        ranges:
+                          description: Ranges are CIDR blocks (IPv4 or IPv6).
+                          items:
+                            type: string
+                          maxItems: 50
+                          minItems: 1
+                          type: array
+                      required:
+                      - ranges
+                      type: object
+                    ipList:
+                      description: |-
+                        IPList references a Cloudflare IP List.
+                        SDK: IPListRule
+                      properties:
+                        id:
+                          description: ID of the IP list in Cloudflare.
+                          maxLength: 36
+                          type: string
+                        name:
+                          description: Name of the IP list (looked up via API).
+                          maxLength: 255
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either id or name must be specified
+                        rule: has(self.id) || has(self.name)
+                    oidcClaim:
+                      description: |-
+                        OIDCClaim matches OIDC token claims.
+                        SDK: AccessOIDCClaimRule
+                      properties:
+                        claimName:
+                          description: ClaimName is the OIDC claim to match.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        claimValue:
+                          description: ClaimValue is the expected value.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        identityProviderId:
+                          description: IdentityProviderID in Cloudflare.
+                          maxLength: 36
+                          minLength: 1
+                          type: string
+                      required:
+                      - claimName
+                      - claimValue
+                      - identityProviderId
+                      type: object
+                    serviceToken:
+                      description: |-
+                        ServiceToken matches a specific service token by ID.
+                        SDK: ServiceTokenRule
+                      properties:
+                        name:
+                          description: |-
+                            Name references an entry in spec.serviceTokens. The controller replaces it
+                            with the created Cloudflare service token ID during policy sync.
+                          maxLength: 255
+                          type: string
+                        tokenId:
+                          description: TokenID is the Cloudflare service token ID.
+                          maxLength: 36
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either tokenId or name must be specified
+                        rule: has(self.tokenId) || has(self.name)
+                  type: object
+                  x-kubernetes-validations:
+                  - message: at least one rule type must be specified
+                    rule: '[has(self.ip), has(self.ipList), has(self.country), has(self.everyone),
+                      has(self.serviceToken), has(self.anyValidServiceToken), has(self.email),
+                      has(self.emailList), has(self.emailDomain), has(self.oidcClaim),
+                      has(self.gsuiteGroup), has(self.group)].exists(x, x)'
+                maxItems: 25
                 type: array
               serviceTokens:
                 description: ServiceTokens for machine-to-machine authentication.
@@ -1039,233 +819,33 @@ spec:
                   type: object
                 maxItems: 10
                 type: array
-              targetRef:
-                description: TargetRef identifies a single target for policy attachment.
-                properties:
-                  group:
-                    default: gateway.networking.k8s.io
-                    description: Group is the API group of the target resource.
-                    type: string
-                  kind:
-                    description: Kind is the kind of the target resource.
-                    enum:
-                    - Gateway
-                    - HTTPRoute
-                    type: string
-                  name:
-                    description: Name is the name of the target resource.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace is the namespace of the target resource.
-                      Cross-namespace targeting requires ReferenceGrant.
-                    type: string
-                  sectionName:
-                    description: SectionName targets specific listener (Gateway) or
-                      rule (Route).
-                    type: string
-                required:
-                - group
-                - kind
-                - name
-                type: object
-                x-kubernetes-validations:
-                - message: group must be gateway.networking.k8s.io
-                  rule: self.group == 'gateway.networking.k8s.io'
-                - message: kind must be Gateway or HTTPRoute
-                  rule: self.kind in ['Gateway', 'HTTPRoute']
-              targetRefs:
-                description: TargetRefs identifies multiple targets for policy attachment.
-                items:
-                  description: |-
-                    PolicyTargetReference identifies a Gateway API resource for Access policy attachment.
-
-                    PolicyTargetReference follows the Gateway API LocalPolicyTargetReferenceWithSectionName
-                    pattern for policy attachment. It targets Gateway API Gateway and HTTPRoute resources
-                    and extracts hostnames from those resources to create corresponding Cloudflare Access
-                    applications.
-
-                    Cross-namespace references require a ReferenceGrant in the target namespace that permits
-                    CloudflareAccessPolicy resources from the policy's namespace.
-                  properties:
-                    group:
-                      default: gateway.networking.k8s.io
-                      description: Group is the API group of the target resource.
-                      type: string
-                    kind:
-                      description: Kind is the kind of the target resource.
-                      enum:
-                      - Gateway
-                      - HTTPRoute
-                      type: string
-                    name:
-                      description: Name is the name of the target resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace is the namespace of the target resource.
-                        Cross-namespace targeting requires ReferenceGrant.
-                      type: string
-                    sectionName:
-                      description: SectionName targets specific listener (Gateway)
-                        or rule (Route).
-                      type: string
-                  required:
-                  - group
-                  - kind
-                  - name
-                  type: object
-                  x-kubernetes-validations:
-                  - message: group must be gateway.networking.k8s.io
-                    rule: self.group == 'gateway.networking.k8s.io'
-                  - message: kind must be Gateway or HTTPRoute
-                    rule: self.kind in ['Gateway', 'HTTPRoute']
-                maxItems: 16
-                type: array
+              sessionDuration:
+                description: SessionDuration overrides application session duration
+                  for this policy.
+                maxLength: 32
+                pattern: ^([0-9]+(ns|us|ms|s|m|h))+$
+                type: string
             required:
-            - application
+            - cloudflareRef
+            - decision
+            - include
+            - name
             type: object
             x-kubernetes-validations:
-            - message: either targetRef or targetRefs must be specified
-              rule: has(self.targetRef) || has(self.targetRefs)
-            - message: targetRef and targetRefs are mutually exclusive
-              rule: '!(has(self.targetRef) && has(self.targetRefs))'
+            - message: include rules are required
+              rule: size(self.include) > 0
           status:
-            description: |-
-              CloudflareAccessPolicyStatus defines the observed state of a CloudflareAccessPolicy resource.
-
-              CloudflareAccessPolicyStatus captures the Cloudflare-assigned identifiers for the
-              Access Application and policies, service token mappings, and per-target attachment status.
+            description: CloudflareAccessPolicyStatus defines the observed state of
+              a CloudflareAccessPolicy resource.
             properties:
-              ancestors:
-                description: Ancestors contains status for each targetRef (Gateway
-                  API PolicyStatus).
-                items:
-                  description: |-
-                    PolicyAncestorStatus describes the policy attachment status for a specific target.
-
-                    PolicyAncestorStatus follows the Gateway API PolicyAncestorStatus pattern to report
-                    per-target attachment status. Each target reference in the spec has a corresponding
-                    ancestor status entry showing whether the policy was successfully attached.
-                  properties:
-                    ancestorRef:
-                      description: AncestorRef identifies the target.
-                      properties:
-                        group:
-                          default: gateway.networking.k8s.io
-                          description: Group is the API group of the target resource.
-                          type: string
-                        kind:
-                          description: Kind is the kind of the target resource.
-                          enum:
-                          - Gateway
-                          - HTTPRoute
-                          type: string
-                        name:
-                          description: Name is the name of the target resource.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace is the namespace of the target resource.
-                            Cross-namespace targeting requires ReferenceGrant.
-                          type: string
-                        sectionName:
-                          description: SectionName targets specific listener (Gateway)
-                            or rule (Route).
-                          type: string
-                      required:
-                      - group
-                      - kind
-                      - name
-                      type: object
-                      x-kubernetes-validations:
-                      - message: group must be gateway.networking.k8s.io
-                        rule: self.group == 'gateway.networking.k8s.io'
-                      - message: kind must be Gateway or HTTPRoute
-                        rule: self.kind in ['Gateway', 'HTTPRoute']
-                    conditions:
-                      description: Conditions for this specific target.
-                      items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
-                        properties:
-                          lastTransitionTime:
-                            description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
-                            type: string
-                          message:
-                            description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
-                            type: string
-                          observedGeneration:
-                            description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    controllerName:
-                      description: ControllerName identifies the controller managing
-                        this attachment.
-                      type: string
-                  required:
-                  - ancestorRef
-                  - controllerName
-                  type: object
-                type: array
-              applicationAud:
-                description: ApplicationAUD is the Application Audience Tag.
+              accountId:
+                description: AccountID is the Cloudflare account ID used for this
+                  policy.
                 type: string
-              applicationId:
-                description: ApplicationID is the Cloudflare Access Application ID.
-                type: string
-              attachedTargets:
-                description: AttachedTargets is the count of successfully attached
-                  targets.
-                format: int32
+              appCount:
+                description: AppCount is the number of Access Applications currently
+                  using this policy.
+                format: int64
                 type: integer
               conditions:
                 description: Conditions describe current state.
@@ -1327,10 +907,35 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              credentialSecretRef:
+                description: |-
+                  CredentialSecretRef is the resolved credentials Secret used for cleanup.
+                  The namespace is always stored explicitly.
+                properties:
+                  name:
+                    description: Name of the secret.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace of the secret. Defaults to the resource's
+                      namespace if empty.
+                    maxLength: 63
+                    type: string
+                required:
+                - name
+                type: object
               observedGeneration:
                 description: ObservedGeneration is the last generation processed.
                 format: int64
                 type: integer
+              policyId:
+                description: PolicyID is the Cloudflare Access reusable policy ID.
+                type: string
+              reusable:
+                description: Reusable reports whether Cloudflare returned this policy
+                  as reusable.
+                type: boolean
               serviceTokenIds:
                 additionalProperties:
                   type: string

--- a/templates/crds/cloudflaredns.yaml
+++ b/templates/crds/cloudflaredns.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: cloudflarednses.cfgate.io
   labels:
@@ -41,7 +41,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          CloudflareDNS is the Schema for the cloudflaredns API.
+          CloudflareDNS is the Schema for the cloudflarednses API.
 
           CloudflareDNS manages DNS record synchronization independently from CloudflareTunnel resources.
           It supports two target modes: tunnel references (for tunnel-based CNAME records) and external
@@ -225,7 +225,7 @@ spec:
                     description: |-
                       Comment configures comment-based ownership.
 
-                      Deprecated: since v0.1.0-alpha.13. All fields are ignored. Will be removed in v0.1.0-alpha.14.
+                      Deprecated: since v0.1.0-alpha.13. All fields are ignored. Will be removed in a future cleanup release.
                     properties:
                       enabled:
                         default: false
@@ -233,7 +233,7 @@ spec:
                           Enabled enables comment-based ownership tracking.
 
                           Deprecated: since v0.1.0-alpha.13. This field is ignored. The controller always
-                          writes a "managed by cfgate" comment. Will be removed in v0.1.0-alpha.14.
+                          writes a "managed by cfgate" comment. Will be removed in a future cleanup release.
                         type: boolean
                       template:
                         default: managed by cfgate
@@ -241,7 +241,7 @@ spec:
                           Template is the comment template.
 
                           Deprecated: since v0.1.0-alpha.13. This field is ignored. The controller always
-                          uses "managed by cfgate" as the comment. Will be removed in v0.1.0-alpha.14.
+                          uses "managed by cfgate" as the comment. Will be removed in a future cleanup release.
                         maxLength: 255
                         type: string
                     type: object
@@ -312,8 +312,9 @@ spec:
                           type: boolean
                         target:
                           description: |-
-                            Target is the CNAME target. Supports template variable {{ .TunnelDomain }}.
-                            Defaults to tunnel domain when tunnelRef is specified.
+                            Target overrides the resolved record target for this hostname.
+                            Supports template variable {{ .TunnelDomain }} when tunnelRef is used.
+                            Defaults to the resource-level resolved target when omitted.
                             Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
                           maxLength: 253
                           type: string

--- a/templates/crds/cloudflaretunnel.yaml
+++ b/templates/crds/cloudflaretunnel.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: cloudflaretunnels.cfgate.io
   labels:


### PR DESCRIPTION
## Summary
- target cfgate 0.2.0-alpha.3 and bump chart version to 1.3.0
- sync CRDs and RBAC from cfgate generated manifests, including CloudflareAccessApplication
- update install docs, notes, Gateway API version, and generated changelog

## Test plan
- helm lint .
- helm template cfgate .
- helm template cfgate . --set installCRDs=false
- helm template cfgate . --set rbac.create=false
- helm template cfgate . -f ci/default-values.yaml