### PR TITLE
chart: target cfgate 0.2.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the cfgate Helm chart are documented in this file.
 
 
+## [1.3.1] - 2026-05-18
+
+### Maintenance
+
+- **(deps)** Update sigstore/cosign-installer action to v4.1.2
+
+### Other
+
+- Target cfgate 0.2.0-alpha.4
+
 ## [1.3.0] - 2026-05-15
 
 ### Features

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cfgate
 description: Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access
 type: application
-version: 1.3.0
-appVersion: "0.2.0-alpha.3"
+version: 1.3.1
+appVersion: "0.2.0-alpha.4"
 kubeVersion: ">= 1.26.0-0"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Installs the cfgate controller, a Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access management.
 
-This chart currently targets cfgate `0.2.0-alpha.3`.
+This chart currently targets cfgate `0.2.0-alpha.4`.
 
 The current cfgate surface managed by this chart includes separate `CloudflareAccessApplication` and `CloudflareAccessPolicy` CRDs for Access application and policy lifecycle management.
 

--- a/templates/crds/cloudflaretunnel.yaml
+++ b/templates/crds/cloudflaretunnel.yaml
@@ -138,7 +138,7 @@ spec:
                     maxItems: 20
                     type: array
                   image:
-                    default: ghcr.io/inherent-design/cloudflared:2026.3.0-h2c.2
+                    default: ghcr.io/inherent-design/cloudflared:2026.5.0-h2c.1
                     description: Image is the cloudflared container image.
                     maxLength: 255
                     type: string


### PR DESCRIPTION
## Summary

- bump chart to `1.3.1` and cfgate `0.2.0-alpha.4`
- sync `CloudflareTunnel` CRD default to `ghcr.io/inherent-design/cloudflared:2026.5.0-h2c.1`
- regenerate changelog for the chart release

## Test plan

```bash
helm lint .
helm template cfgate .
helm template cfgate . --set installCRDs=false
helm template cfgate . --set rbac.create=false
helm template cfgate . -f ci/default-values.yaml
```

Checked rendered defaults for cfgate `0.2.0-alpha.4` and cloudflared h2c `2026.5.0-h2c.1`. Local `actionlint` binary is not installed; CI covers it.