### PR TITLE
chart: target cfgate 0.2.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,16 @@
 All notable changes to the cfgate Helm chart are documented in this file.
 
 
-## [1.4.0] - 2026-05-22
+## [1.4.0] - 2026-05-24
+
+### Documentation
+
+- Document alpha.5 upgrade risks
 
 ### Other
 
-- Sync cfgate 0.2.0-alpha.5 CRDs
+- Target cfgate 0.2.0-alpha.5
+- Finish alpha.5 CRD sync
 
 ## [1.3.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the cfgate Helm chart are documented in this file.
 
 
+## [1.4.0] - 2026-05-22
+
+### Other
+
+- Sync cfgate 0.2.0-alpha.5 CRDs
+
 ## [1.3.1] - 2026-05-18
 
 ### Maintenance

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cfgate
 description: Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access
 type: application
-version: 1.3.1
-appVersion: "0.2.0-alpha.4"
+version: 1.4.0
+appVersion: "0.2.0-alpha.5"
 kubeVersion: ">= 1.26.0-0"
 
 keywords:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ helm upgrade cfgate oci://ghcr.io/cfgate/charts/cfgate \
   --namespace cfgate-system
 ```
 
+### Upgrade from 1.3.1 to 1.4.0
+
+Chart 1.4.0 installs cfgate `0.2.0-alpha.5` CRDs with stricter validation.
+Before upgrading existing clusters:
+
+- Change any `CloudflareAccessApplication.spec.application.type` value other than `self_hosted` to `self_hosted`.
+- Split any `CloudflareAccessPolicy` rule entry that sets multiple matcher types into separate rule entries.
+- Replace `CloudflareAccessPolicy` `emailList.name` and `ipList.name` references with Cloudflare list IDs.
+- Update alerts or automation keyed on old condition names:
+  - `CloudflareDNS`: use `ZonesResolved`, `RecordsSynced`, and `OwnershipVerified`.
+  - `CloudflareTunnel`: use `TunnelReady` and `CloudflaredDeployed`.
+
 ## Uninstall
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Installs the cfgate controller, a Gateway API-native Kubernetes operator for Cloudflare Tunnel, DNS, and Access management.
 
-This chart currently targets cfgate `0.2.0-alpha.4`.
+This chart currently targets cfgate `0.2.0-alpha.5`.
 
 The current cfgate surface managed by this chart includes separate `CloudflareAccessApplication` and `CloudflareAccessPolicy` CRDs for Access application and policy lifecycle management.
 

--- a/templates/crds/cloudflareaccessapplication.yaml
+++ b/templates/crds/cloudflareaccessapplication.yaml
@@ -254,10 +254,6 @@ spec:
                     description: Type is the application type.
                     enum:
                     - self_hosted
-                    - saas
-                    - ssh
-                    - vnc
-                    - browser_isolation
                     type: string
                 type: object
                 x-kubernetes-validations:

--- a/templates/crds/cloudflareaccesspolicy.yaml
+++ b/templates/crds/cloudflareaccesspolicy.yaml
@@ -224,13 +224,15 @@ spec:
                           maxLength: 36
                           type: string
                         name:
-                          description: Name of the Access list (looked up via API).
+                          description: |-
+                            Name is not supported for lookup in v1alpha1. Specify id instead.
+                            Deprecated: use id.
                           maxLength: 255
                           type: string
                       type: object
                       x-kubernetes-validations:
-                      - message: either id or name must be specified
-                        rule: has(self.id) || has(self.name)
+                      - message: id must be specified
+                        rule: has(self.id)
                     everyone:
                       description: |-
                         Everyone matches all users (use with caution).
@@ -293,13 +295,15 @@ spec:
                           maxLength: 36
                           type: string
                         name:
-                          description: Name of the IP list (looked up via API).
+                          description: |-
+                            Name is not supported for lookup in v1alpha1. Specify id instead.
+                            Deprecated: use id.
                           maxLength: 255
                           type: string
                       type: object
                       x-kubernetes-validations:
-                      - message: either id or name must be specified
-                        rule: has(self.id) || has(self.name)
+                      - message: id must be specified
+                        rule: has(self.id)
                     oidcClaim:
                       description: |-
                         OIDCClaim matches OIDC token claims.
@@ -346,11 +350,12 @@ spec:
                         rule: has(self.tokenId) || has(self.name)
                   type: object
                   x-kubernetes-validations:
-                  - message: at least one rule type must be specified
+                  - message: exactly one rule type must be specified
                     rule: '[has(self.ip), has(self.ipList), has(self.country), has(self.everyone),
                       has(self.serviceToken), has(self.anyValidServiceToken), has(self.email),
                       has(self.emailList), has(self.emailDomain), has(self.oidcClaim),
-                      has(self.gsuiteGroup), has(self.group)].exists(x, x)'
+                      has(self.gsuiteGroup), has(self.group)].filter(x, x).size()
+                      == 1'
                 maxItems: 25
                 type: array
               include:
@@ -430,13 +435,15 @@ spec:
                           maxLength: 36
                           type: string
                         name:
-                          description: Name of the Access list (looked up via API).
+                          description: |-
+                            Name is not supported for lookup in v1alpha1. Specify id instead.
+                            Deprecated: use id.
                           maxLength: 255
                           type: string
                       type: object
                       x-kubernetes-validations:
-                      - message: either id or name must be specified
-                        rule: has(self.id) || has(self.name)
+                      - message: id must be specified
+                        rule: has(self.id)
                     everyone:
                       description: |-
                         Everyone matches all users (use with caution).
@@ -499,13 +506,15 @@ spec:
                           maxLength: 36
                           type: string
                         name:
-                          description: Name of the IP list (looked up via API).
+                          description: |-
+                            Name is not supported for lookup in v1alpha1. Specify id instead.
+                            Deprecated: use id.
                           maxLength: 255
                           type: string
                       type: object
                       x-kubernetes-validations:
-                      - message: either id or name must be specified
-                        rule: has(self.id) || has(self.name)
+                      - message: id must be specified
+                        rule: has(self.id)
                     oidcClaim:
                       description: |-
                         OIDCClaim matches OIDC token claims.
@@ -552,11 +561,12 @@ spec:
                         rule: has(self.tokenId) || has(self.name)
                   type: object
                   x-kubernetes-validations:
-                  - message: at least one rule type must be specified
+                  - message: exactly one rule type must be specified
                     rule: '[has(self.ip), has(self.ipList), has(self.country), has(self.everyone),
                       has(self.serviceToken), has(self.anyValidServiceToken), has(self.email),
                       has(self.emailList), has(self.emailDomain), has(self.oidcClaim),
-                      has(self.gsuiteGroup), has(self.group)].exists(x, x)'
+                      has(self.gsuiteGroup), has(self.group)].filter(x, x).size()
+                      == 1'
                 maxItems: 25
                 minItems: 1
                 type: array
@@ -651,13 +661,15 @@ spec:
                           maxLength: 36
                           type: string
                         name:
-                          description: Name of the Access list (looked up via API).
+                          description: |-
+                            Name is not supported for lookup in v1alpha1. Specify id instead.
+                            Deprecated: use id.
                           maxLength: 255
                           type: string
                       type: object
                       x-kubernetes-validations:
-                      - message: either id or name must be specified
-                        rule: has(self.id) || has(self.name)
+                      - message: id must be specified
+                        rule: has(self.id)
                     everyone:
                       description: |-
                         Everyone matches all users (use with caution).
@@ -720,13 +732,15 @@ spec:
                           maxLength: 36
                           type: string
                         name:
-                          description: Name of the IP list (looked up via API).
+                          description: |-
+                            Name is not supported for lookup in v1alpha1. Specify id instead.
+                            Deprecated: use id.
                           maxLength: 255
                           type: string
                       type: object
                       x-kubernetes-validations:
-                      - message: either id or name must be specified
-                        rule: has(self.id) || has(self.name)
+                      - message: id must be specified
+                        rule: has(self.id)
                     oidcClaim:
                       description: |-
                         OIDCClaim matches OIDC token claims.
@@ -773,11 +787,12 @@ spec:
                         rule: has(self.tokenId) || has(self.name)
                   type: object
                   x-kubernetes-validations:
-                  - message: at least one rule type must be specified
+                  - message: exactly one rule type must be specified
                     rule: '[has(self.ip), has(self.ipList), has(self.country), has(self.everyone),
                       has(self.serviceToken), has(self.anyValidServiceToken), has(self.email),
                       has(self.emailList), has(self.emailDomain), has(self.oidcClaim),
-                      has(self.gsuiteGroup), has(self.group)].exists(x, x)'
+                      has(self.gsuiteGroup), has(self.group)].filter(x, x).size()
+                      == 1'
                 maxItems: 25
                 type: array
               serviceTokens:

--- a/templates/crds/cloudflaredns.yaml
+++ b/templates/crds/cloudflaredns.yaml
@@ -55,9 +55,9 @@ spec:
           Status conditions:
             - Ready: DNS sync is fully operational
             - CredentialsValid: Cloudflare credentials have been validated
-            - TargetResolved: Tunnel reference or external target has been resolved
-            - ZonesDiscovered: All configured zones have been discovered via API
-            - DNSSynced: DNS records have been synchronized to Cloudflare
+            - ZonesResolved: All configured zones have been resolved via API
+            - RecordsSynced: DNS records have been synchronized to Cloudflare
+            - OwnershipVerified: TXT ownership records have been verified, when enabled
         properties:
           apiVersion:
             description: |-

--- a/templates/crds/cloudflaretunnel.yaml
+++ b/templates/crds/cloudflaretunnel.yaml
@@ -51,9 +51,9 @@ spec:
           Status conditions:
             - Ready: tunnel is fully operational
             - CredentialsValid: API credentials have been validated
-            - TunnelCreated: tunnel exists in Cloudflare
+            - TunnelReady: tunnel exists in Cloudflare
             - ConfigurationSynced: ingress configuration is synced
-            - DeploymentReady: cloudflared pods are running
+            - CloudflaredDeployed: cloudflared pods are running
         properties:
           apiVersion:
             description: |-


### PR DESCRIPTION
## Summary
- target cfgate 0.2.0-alpha.5 with chart version 1.4.0
- sync AccessApplication, AccessPolicy, DNS, and Tunnel CRD changes for alpha.5
- keep values, RBAC, and deployment templates unchanged because upstream alpha.5 did not change their sources

## Test plan
- rg stale alpha.4 CRD markers under templates/crds
- rg expected alpha.5 CRD markers under templates/crds
- helm lint .
- helm template cfgate .
- helm template cfgate . --set installCRDs=false
- helm template cfgate . --set rbac.create=false